### PR TITLE
Declare networkx as an optional dependency and guard its import

### DIFF
--- a/optimalportfolios/covar_estimation/risk_labelling.py
+++ b/optimalportfolios/covar_estimation/risk_labelling.py
@@ -314,7 +314,13 @@ def _match_panel_mcf(snapshots: Dict[pd.Timestamp, Dict[Any, _Fingerprint]],
     whole panel jointly so bridge edges can route a persistent cluster's
     identity *around* a transient merge/split rather than handing it off locally.
     """
-    import networkx as nx
+    try:
+        import networkx as nx
+    except ImportError as e:
+        raise ImportError(
+            "the 'mcf' matcher needs networkx: pip install optimalportfolios[clustering]. "
+            "Alternatively pass method='hungarian', which needs no extra."
+        ) from e
     dates = sorted(snapshots.keys())
     didx = {d: i for i, d in enumerate(dates)}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,12 @@ visualization = [
     "plotly>=5.0.0",
 ]
 
+# the default 'mcf' matcher in covar_estimation.risk_labelling solves a min-cost-flow
+# path cover with networkx; the 'hungarian' matcher needs nothing extra.
+clustering = [
+    "networkx>=3.0",
+]
+
 jupyter = [
     "jupyter>=1.0.0",
     "notebook>=6.5.0",
@@ -81,11 +87,11 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "ruff>=0.4",
-    "optimalportfolios[data]",
+    "optimalportfolios[data,clustering]",
 ]
 
 all = [
-    "optimalportfolios[data,reports,visualization,jupyter]",
+    "optimalportfolios[data,reports,visualization,jupyter,clustering]",
 ]
 
 [project.urls]
@@ -134,7 +140,7 @@ extend-select = ["TID251", "TID253", "ICN"]
 # core install keeps working. A module dedicated to a single optional backend is the documented
 # exception and is named in per-file-ignores below.
 banned-module-level-imports = ["yfinance", "pandas_datareader", "pybloqs", "plotly", "pyarrow",
-                               "psycopg2", "sqlalchemy"]
+                               "psycopg2", "sqlalchemy", "networkx"]
 
 [tool.ruff.lint.flake8-import-conventions.aliases]
 # replaces ruff's default alias map, which also demands `matplotlib as mpl` everywhere. Only


### PR DESCRIPTION
Closes #12.

`optimalportfolios/covar_estimation/risk_labelling.py:317` imported `networkx`, but the package was declared in no extra — so the code path could not be reached by any published install. It is not an exotic path: `method='mcf'` is the **default** for `analyze_risk_clusters` (line 666), and the module docstring at line 18 documents it as the recommended matcher.

The import was also bare, against the convention in AGENTS.md:56 ("put an optional import inside the function that needs it and raise `ImportError` naming the extra"), so a user reaching it got a raw `ModuleNotFoundError: No module named 'networkx'` with no indication of what to install.

## Changes

- **New `clustering` extra** declaring `networkx>=3.0`, added to `all` and to `dev`. Including it in `dev` means CI can exercise the default matcher — it currently cannot, which is part of why this went unnoticed.
- **Guarded the import**, naming both the extra and the dependency-free `hungarian` alternative:
  ```
  ImportError: the 'mcf' matcher needs networkx: pip install optimalportfolios[clustering].
  Alternatively pass method='hungarian', which needs no extra.
  ```
- **Added `networkx` to `banned-module-level-imports`**, so `TID253` keeps the import out of module scope — the same treatment every other optional extra gets. Without it, the guard could be undone silently.

## Verification

| Check | Result |
|---|---|
| `ruff check optimalportfolios/ --select TID251,TID253,ICN` | `All checks passed!` |
| `deptry` — `DEP001 networkx` | cleared |
| Full `pytest` suite | passes (exit 0) |
| `ImportError` path, in an env with networkx absent | raises the message above, chained from `ModuleNotFoundError` |

The error path was exercised in a virtualenv with `networkx` genuinely uninstalled, so that message is observed output rather than predicted.

## Notes for review

- **The extra's name is a free choice.** `clustering` is not dictated by anything; `graph` would fit too, since the dispatch at line 677 accepts `method in ('mcf', 'graph')`. Happy to rename.
- **No test covers the guard.** `risk_labelling.py` is at 0% coverage (440/440 statements missed) and has no test module, so there is nothing to hang one off. That is the subject of a separate issue; adding a regression test here would also be slightly awkward now that `dev` installs `networkx`.
- Adding `clustering` to `dev` changes what the CI `test` job installs. The `core-install` job is unaffected — it asserts only that `yfinance`, `pandas_datareader` and `pybloqs` are absent.
