### PR TITLE
CI: gate the three ruff stack invariants (TID251/TID253/ICN)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,32 @@ env:
   MPLBACKEND: Agg
 
 jobs:
+  lint:
+    # The three stack invariants configured in pyproject.toml -- TID251 (subject packages
+    # never import each other), TID253 (an optional extra is never imported at module
+    # level) and ICN (the numpy/pandas aliases) -- are green across the whole package, so
+    # a finding here is always something the change under review introduced.
+    #
+    # Deliberately not the full E/W/F set: that carries a large legacy backlog which
+    # AGENTS.md asks be left alone, so gating it would block every unrelated PR.
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install ruff
+      run: |
+        python -m pip install --upgrade pip
+        pip install "ruff>=0.4"
+
+    - name: Check stack invariants
+      run: ruff check --select TID251,TID253,ICN optimalportfolios/
+
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Closes #11.

AGENTS.md:75 states that three stack invariants are "enforced by ruff rather than written down". They are configured in `pyproject.toml` (lines 117–143), but **no CI step ran ruff** — AGENTS.md:109 says so directly: *"CI does not gate on lint."* So the invariants were upheld by author discipline alone. AGENTS.md:77 notes the `TID253` constraint "has already been broken twice by a module-scope yfinance import".

## The change

One new `lint` job running:

```
ruff check --select TID251,TID253,ICN optimalportfolios/
```

- **`TID251`** — subject packages never import each other
- **`TID253`** — an optional extra is never imported at module level
- **`ICN`** — the `numpy as np` / `pandas as pd` aliases

## Why this is safe to merge as-is

The command is **already green** on the package, so the gate goes from red-never to green-now with no cleanup commit:

```
$ ruff check --select TID251,TID253,ICN optimalportfolios/
All checks passed!
```

The wider `E`/`W`/`F` set is **deliberately left ungated**. It carries ~764 findings, almost all `E501`, and AGENTS.md:109 asks that they be left alone ("Fix only the lines your specific change touches; a repository-wide reflow is not wanted"). Gating it would block every unrelated PR. Scoping to the invariants keeps that policy intact while making the rules that matter enforceable.

## Verification

I checked that the gate both passes *and* fails, since a gate that can never fail is not a gate. Against a scratch file importing `stochvolmodels`, `yfinance` at module level, and `numpy as npp`:

```
TID251 `stochvolmodels` is banned: A1: subject packages never import each other.
TID253 `yfinance` is banned at the module level
ICN001 `numpy` should be imported as `np`
Found 3 errors.   (exit 1)
```

All three fire. The scratch file was removed afterwards; this PR touches only `.github/workflows/ci.yml`.

## Notes for review

- **Separate job, not a step in the `test` matrix.** #11 suggested adding a step to `test`; a standalone job avoids running an identical, version-independent lint three times, and gives it its own check name. Easy to fold into `test` instead if you prefer fewer jobs.
- **`ruff>=0.4`** matches the floor already declared in the `dev` extra, so no new version constraint is introduced. It does mean the job picks up new ruff releases — the three selected rule families are stable, but pinning is an option if you'd rather.
- The job is not marked required; that is a branch-protection setting rather than something this PR can carry.
