### PR TITLE
Guard the root-package import cycle with a regression test

### DIFF
--- a/optimalportfolios/optimization/wrapper_rolling_portfolios.py
+++ b/optimalportfolios/optimization/wrapper_rolling_portfolios.py
@@ -104,59 +104,59 @@ def compute_rolling_optimal_weights(prices: pd.DataFrame,
     """
     if portfolio_objective == PortfolioObjective.EQUAL_RISK_CONTRIBUTION:
         weights = rolling_risk_budgeting(prices=prices,
-                                             constraints=constraints,
-                                             covar_dict=covar_dict,
-                                             risk_budget=risk_budget,
-                                             optimiser_config=optimiser_config)
+                                         constraints=constraints,
+                                         covar_dict=covar_dict,
+                                         risk_budget=risk_budget,
+                                         optimiser_config=optimiser_config)
 
     elif portfolio_objective == PortfolioObjective.MAX_DIVERSIFICATION:
         weights = rolling_maximise_diversification(prices=prices,
-                                                       constraints=constraints,
-                                                       covar_dict=covar_dict,
-                                                       optimiser_config=optimiser_config)
+                                                   constraints=constraints,
+                                                   covar_dict=covar_dict,
+                                                   optimiser_config=optimiser_config)
 
     elif portfolio_objective == PortfolioObjective.MIN_VARIANCE:
         weights = rolling_quadratic_optimisation(prices=prices,
-                                                     constraints=constraints,
-                                                     portfolio_objective=portfolio_objective,
-                                                     covar_dict=covar_dict,
-                                                     carra=carra,
-                                                     optimiser_config=optimiser_config)
+                                                 constraints=constraints,
+                                                 portfolio_objective=portfolio_objective,
+                                                 covar_dict=covar_dict,
+                                                 carra=carra,
+                                                 optimiser_config=optimiser_config)
 
     elif portfolio_objective == PortfolioObjective.QUADRATIC_UTILITY:
         expected_returns = estimate_rolling_ewma_means(prices=prices,
-                                                rebalancing_dates=list(covar_dict.keys()),
-                                                returns_freq=returns_freq,
-                                                span=span, annualize=True)
+                                                       rebalancing_dates=list(covar_dict.keys()),
+                                                       returns_freq=returns_freq,
+                                                       span=span, annualize=True)
         weights = rolling_quadratic_optimisation(prices=prices,
-                                                     constraints=constraints,
-                                                     portfolio_objective=portfolio_objective,
-                                                     covar_dict=covar_dict,
-                                                     expected_returns=expected_returns,
-                                                     carra=carra,
-                                                     optimiser_config=optimiser_config)
+                                                 constraints=constraints,
+                                                 portfolio_objective=portfolio_objective,
+                                                 covar_dict=covar_dict,
+                                                 expected_returns=expected_returns,
+                                                 carra=carra,
+                                                 optimiser_config=optimiser_config)
 
     elif portfolio_objective == PortfolioObjective.MAXIMUM_SHARPE_RATIO:
         expected_returns = estimate_rolling_ewma_means(prices=prices,
-                                                rebalancing_dates=list(covar_dict.keys()),
-                                                returns_freq=returns_freq,
-                                                span=span, annualize=True)
+                                                       rebalancing_dates=list(covar_dict.keys()),
+                                                       returns_freq=returns_freq,
+                                                       span=span, annualize=True)
         weights = rolling_maximize_portfolio_sharpe(prices=prices,
-                                                        expected_returns=expected_returns,
-                                                        constraints=constraints,
-                                                        covar_dict=covar_dict,
-                                                        optimiser_config=optimiser_config)
+                                                    expected_returns=expected_returns,
+                                                    constraints=constraints,
+                                                    covar_dict=covar_dict,
+                                                    optimiser_config=optimiser_config)
 
     elif portfolio_objective == PortfolioObjective.MAX_CARA_MIXTURE:
         weights = rolling_maximize_cara_mixture(prices=prices,
-                                                    constraints=constraints,
-                                                    time_period=time_period,
-                                                    returns_freq=returns_freq,
-                                                    rebalancing_freq=rebalancing_freq,
-                                                    carra=carra,
-                                                    n_components=n_mixures,
-                                                    roll_window=roll_window,
-                                                    optimiser_config=optimiser_config)
+                                                constraints=constraints,
+                                                time_period=time_period,
+                                                returns_freq=returns_freq,
+                                                rebalancing_freq=rebalancing_freq,
+                                                carra=carra,
+                                                n_components=n_mixures,
+                                                roll_window=roll_window,
+                                                optimiser_config=optimiser_config)
 
     else:
         raise NotImplementedError(f"{portfolio_objective}")

--- a/optimalportfolios/reports/marginal_backtest.py
+++ b/optimalportfolios/reports/marginal_backtest.py
@@ -137,59 +137,59 @@ def backtest_marginal_optimal_portfolios(prices: pd.DataFrame,  # for inclusion 
     elif optimisation_type == OptimisationType.ERC:
         constraints = Constraints()
         weights_wo = rolling_risk_budgeting(prices=prices_without_asset,
-                                                constraints=constraints,
-                                                risk_budget=budget_wo,
-                                                covar_dict=covar_dict)
+                                            constraints=constraints,
+                                            risk_budget=budget_wo,
+                                            covar_dict=covar_dict)
         weights_with = rolling_risk_budgeting(prices=prices_with_asset,
-                                                  constraints=constraints,
-                                                  risk_budget=budget_with,
-                                                  covar_dict=covar_dict)
+                                              constraints=constraints,
+                                              risk_budget=budget_with,
+                                              covar_dict=covar_dict)
 
     elif optimisation_type == OptimisationType.MAX_DIV:
         weights_wo = rolling_maximise_diversification(prices=prices_without_asset,
-                                                          constraints=Constraints(min_weights=weight_min_wo, max_weights=weight_max_wo),
-                                                          covar_dict=covar_dict)
+                                                      constraints=Constraints(min_weights=weight_min_wo, max_weights=weight_max_wo),
+                                                      covar_dict=covar_dict)
         weights_with = rolling_maximise_diversification(prices=prices_with_asset,
-                                                            constraints=Constraints(min_weights=weight_min_with, max_weights=weight_max_with),
-                                                            covar_dict=covar_dict)
+                                                        constraints=Constraints(min_weights=weight_min_with, max_weights=weight_max_with),
+                                                        covar_dict=covar_dict)
 
     elif optimisation_type == OptimisationType.MAX_SHARPE:
         rebalancing_dates = list(covar_dict.keys())
         means_wo = estimate_rolling_ewma_means(prices=prices_without_asset,
-                                                rebalancing_dates=rebalancing_dates,
-                                                returns_freq=returns_freq,
-                                                span=span, annualize=True)
+                                               rebalancing_dates=rebalancing_dates,
+                                               returns_freq=returns_freq,
+                                               span=span, annualize=True)
         weights_wo = rolling_maximize_portfolio_sharpe(prices=prices_without_asset,
-                                                           expected_returns=means_wo,
-                                                           constraints=Constraints(min_weights=weight_min_wo, max_weights=weight_max_wo),
-                                                           covar_dict=covar_dict)
+                                                       expected_returns=means_wo,
+                                                       constraints=Constraints(min_weights=weight_min_wo, max_weights=weight_max_wo),
+                                                       covar_dict=covar_dict)
         means_with = estimate_rolling_ewma_means(prices=prices_with_asset,
-                                                rebalancing_dates=rebalancing_dates,
-                                                returns_freq=returns_freq,
-                                                span=span, annualize=True)
+                                                 rebalancing_dates=rebalancing_dates,
+                                                 returns_freq=returns_freq,
+                                                 span=span, annualize=True)
         weights_with = rolling_maximize_portfolio_sharpe(prices=prices_with_asset,
-                                                             expected_returns=means_with,
-                                                             constraints=Constraints(min_weights=weight_min_with, max_weights=weight_max_with),
-                                                             covar_dict=covar_dict)
+                                                         expected_returns=means_with,
+                                                         constraints=Constraints(min_weights=weight_min_with, max_weights=weight_max_with),
+                                                         covar_dict=covar_dict)
 
     elif optimisation_type == OptimisationType.MIXTURE:
         weights_wo = rolling_maximize_cara_mixture(prices=prices_without_asset,
-                                                       constraints=Constraints(min_weights=weight_min_wo, max_weights=weight_max_wo),
-                                                       time_period=time_period,
-                                                       returns_freq=returns_freq,
-                                                       rebalancing_freq=rebalancing_freq,
-                                                       carra=carra,
-                                                       n_components=n_mixures,
-                                                       roll_window=roll_window)
+                                                   constraints=Constraints(min_weights=weight_min_wo, max_weights=weight_max_wo),
+                                                   time_period=time_period,
+                                                   returns_freq=returns_freq,
+                                                   rebalancing_freq=rebalancing_freq,
+                                                   carra=carra,
+                                                   n_components=n_mixures,
+                                                   roll_window=roll_window)
 
         weights_with = rolling_maximize_cara_mixture(prices=prices_with_asset,
-                                                         constraints=Constraints(min_weights=weight_min_with, max_weights=weight_max_with),
-                                                         time_period=time_period,
-                                                         returns_freq=returns_freq,
-                                                         rebalancing_freq=rebalancing_freq,
-                                                         carra=carra,
-                                                         n_components=n_mixures,
-                                                         roll_window=roll_window)
+                                                     constraints=Constraints(min_weights=weight_min_with, max_weights=weight_max_with),
+                                                     time_period=time_period,
+                                                     returns_freq=returns_freq,
+                                                     rebalancing_freq=rebalancing_freq,
+                                                     carra=carra,
+                                                     n_components=n_mixures,
+                                                     roll_window=roll_window)
 
     else:
         raise NotImplementedError

--- a/optimalportfolios/tests/root_import_cycle_test.py
+++ b/optimalportfolios/tests/root_import_cycle_test.py
@@ -1,0 +1,81 @@
+"""
+no library module imports the top-level ``optimalportfolios`` package.
+
+``optimalportfolios/__init__.py`` star-imports the subpackages in sequence. A library module
+that imports back through the package root therefore re-enters a *partially initialised*
+module, and whether the name it wants is already bound depends on nothing but the order of
+those star-imports.
+
+This bit for real. ``optimization/taa/maximise_alpha_with_target_yield.py`` did
+``from optimalportfolios import filter_covar_and_vectors_for_nans``. That symbol is defined in
+``utils/filter_nans.py``, star-imported four lines above ``optimization`` - so the package
+imported cleanly, and reversing those six lines produced
+``ImportError: cannot import name 'filter_covar_and_vectors_for_nans' from partially
+initialized module 'optimalportfolios' (most likely due to a circular import)``. Two further
+modules, ``optimization/wrapper_rolling_portfolios.py`` and ``reports/marginal_backtest.py``,
+did ``import optimalportfolios as opt``; those survived only because attribute lookup on a
+module object is deferred to call time, which makes them the same latent cycle one step from
+failing.
+
+A `from` import is the failing form and a plain `import` the merely fragile one, so the check
+covers both: a library module imports the module that *defines* what it needs, never the root.
+
+Examples and tests are excluded. An example is read top to bottom by a user, for whom
+``import optimalportfolios as opt`` is the documented entry point, and a test imports the
+package the way a caller would.
+
+To confirm this check can fail, put ``from optimalportfolios import Constraints`` at the top of
+any module under ``optimization/``: the site is reported below by file and line. That was run
+before this file was committed.
+"""
+# packages
+import ast
+from pathlib import Path
+from typing import List, Tuple
+# optimalportfolios
+import optimalportfolios
+
+PACKAGE_ROOT: Path = Path(optimalportfolios.__file__).parent
+PACKAGE_NAME: str = optimalportfolios.__name__
+
+# directories whose contents are scripts rather than library code: an example is read by a user
+# and a test imports the package the way a caller would, so neither carries the convention
+EXCLUDED_PARTS: Tuple[str, ...] = ('examples', 'tests', 'notebooks')
+
+
+def find_root_package_imports() -> List[str]:
+    """Return one line per library module importing the top-level package at module scope."""
+    offenders = []
+    for path in sorted(PACKAGE_ROOT.rglob('*.py')):
+        if any(part in EXCLUDED_PARTS for part in path.parts):
+            continue
+        if path.name.endswith(('_test.py', '_tests.py')) or path.name == '__init__.py':
+            continue
+        tree = ast.parse(path.read_text(encoding='utf-8'))
+        rel = path.relative_to(PACKAGE_ROOT.parent).as_posix()
+        for node in ast.walk(tree):
+            # `from optimalportfolios import x` -- fails outright on an unlucky ordering
+            if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module == PACKAGE_NAME:
+                names = ', '.join(alias.name for alias in node.names)
+                offenders.append(f"{rel}:{node.lineno}: from {PACKAGE_NAME} import {names}")
+            # `import optimalportfolios [as opt]` -- the same cycle, deferred to call time
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == PACKAGE_NAME:
+                        as_part = f" as {alias.asname}" if alias.asname else ''
+                        offenders.append(f"{rel}:{node.lineno}: import {PACKAGE_NAME}{as_part}")
+    return offenders
+
+
+def test_no_library_module_imports_the_root_package() -> None:
+    """a library module importing the package root re-enters it partially initialised"""
+    offenders = find_root_package_imports()
+    assert not offenders, (
+            "library module imports the top-level package, creating an import cycle that survives "
+            "only on the star-import order in __init__.py; import the defining module instead:\n"
+            + '\n'.join(offenders))
+
+
+if __name__ == '__main__':
+    for offender in find_root_package_imports():
+        print(offender)


### PR DESCRIPTION
Closes #14.

Three library modules imported back through `optimalportfolios/__init__.py`, re-entering a partially initialised module. Whether that worked depended on nothing but the order of the six star-imports in `__init__.py`.

**The code fix has since landed on `main` independently.** This branch was rebased onto it, and what remains is the enforcing test plus a whitespace correction. The sections below describe the diff as it now stands.

## What is left in this diff

`optimization/taa/maximise_alpha_with_target_yield.py` is now byte-identical to `main` and has dropped out of the diff entirely.

In `optimization/wrapper_rolling_portfolios.py` and `reports/marginal_backtest.py`, `main` already dropped the `opt.` prefix but left the continuation lines aligned to the old, longer call. This realigns them to the open paren. Verified `diff -w` against `main`: identical modulo whitespace, so no argument, default or control flow changes.

## The cycle this guards against

`optimalportfolios/optimization/taa/maximise_alpha_with_target_yield.py:39` was the failing form:

```python
from optimalportfolios import filter_covar_and_vectors_for_nans
```

That symbol is defined in `utils/filter_nans.py`, star-imported four lines above `optimization` — so the package imported cleanly. Reversing those six lines produced:

```
ImportError: cannot import name 'filter_covar_and_vectors_for_nans' from partially
initialized module 'optimalportfolios' (most likely due to a circular import)
```

`optimization/wrapper_rolling_portfolios.py:53` and `reports/marginal_backtest.py:12` did `import optimalportfolios as opt`. Those survived only because attribute lookup on a module object is deferred to call time — the same cycle, one step from failing.

## Regression test

`optimalportfolios/tests/root_import_cycle_test.py` — an AST scan asserting no library module imports the root package at module scope, catching both the `from` form and the deferred `import … as` form. It follows the pattern of `tests/concat_sort_convention_test.py` (same exclusions, same `__main__` reporting block). Examples and tests are excluded: for them the root import is the documented entry point.

Both forms were probed against the rebased tree to confirm the check is not vacuous. Appending to `optimization/constraints.py`:

```
from optimalportfolios import Constraints   → circular ImportError at collection
import optimalportfolios as opt             → imports cleanly; scan reports
                                              optimalportfolios/optimization/constraints.py:1894
```

## Verification

- `pytest` — 631 passed, 1 skipped (`risk_labelling_test.py`, needs `networkx`)
- `interrogate` — 100.0%
- `ruff check --select TID251,TID253,ICN` — clean
- Bare `ruff check optimalportfolios/` reports 762 errors both here and on `main` — pre-existing, unchanged by this PR

## Not in scope

The issue notes separately that the six `from <pkg>.__init__ import *` statements are an unusual form (`from <pkg> import *` is equivalent and conventional) and that the absent `__all__` makes the public surface implicit — together the 6 × `F403`. Left alone here, as neither is part of the issue's `done when`. Happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
