### PR TITLE
Test Python 3.13 in CI, which pyproject already advertises

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ interrogate                                              # docstring coverage, m
 
 *Note: Terminal execution should be compatible with Windows PowerShell within PyCharm.*
 
-Optional extras: `data`, `reports`, `visualization`, `clustering`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.12 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Separate jobs gate the three ruff stack invariants and `interrogate` docstring coverage at 100%. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
+Optional extras: `data`, `reports`, `visualization`, `clustering`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Separate jobs gate the three ruff stack invariants and `interrogate` docstring coverage at 100%. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
 
 Full-package line coverage measured **62.97%** on the 627-test dev suite after S6. The Python
 3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 61`; this floor rises


### PR DESCRIPTION
Closes #28.

## Summary

`pyproject.toml:38` carries the `Programming Language :: Python :: 3.13` classifier, but the CI matrix stopped at 3.12 — so 3.13 was advertised to installers and never exercised. This adds it to the matrix.

Of the two directions #28 offered (test 3.13, or drop the classifier), the evidence supports testing it: the whole stack works on 3.13 today, so dropping the claim would have given up support the project already has.

## Verified on CPython 3.13.14 before changing the matrix

Rather than assuming wheels exist for the compiled dependencies:

| Check | Result |
|---|---|
| Core install resolves | ✅ incl. `quadprog` 0.1.13, `scipy` 1.18.0 |
| `[dev]` install resolves | ✅ incl. `yfinance` 1.5.2, `ruff` 0.16.2 |
| Suite on `[dev]` install | ✅ **631 passed** — identical to 3.12 |
| Suite on core install | ✅ 630 passed, 1 skipped |
| `Verify imports` step | ✅ |
| `Verify factorlasso integration` step | ✅ |

The single skip on the core install is `risk_labelling_test.py:152` — `could not import 'networkx'` — which is the `clustering` extra's guard behaving exactly as documented, not a 3.13 failure.

## Scope

- The coverage gate stays pinned to the 3.12 entry (`if: matrix.python-version == '3.12'`), so 3.13 runs the plain suite. No change to `fail_under`.
- `AGENTS.md:70` mirrored the old range in prose and is updated in the same commit.
- `CHANGELOG.md:49` and `README.md:987` also read "3.10–3.12", but both are release-history entries describing what a past version did, so they are deliberately left as the record they are.
- The `requires-python = ">=3.10"` floor is untouched — #28 mentioned an unmerged branch that would raise it to 3.11, which is a separate decision.

## Test plan

- `fail-fast: false` is already set on the `test` job, so if a 3.13 wheel gap appears later it surfaces without masking the other three versions.
- CI on this PR exercises the new entry directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)