### PR TITLE
Land validated import-cycle regression guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
+- Added a module-scope root-package import-cycle regression guard, adapted from PR #22 by
+  @tschm, while retaining function- and method-local import support.
 - ROSAA model execution supports an inert-by-default desk-instruction correction dead-band.
   Current Min/Max and explicit minimum, maximum or fixed-target breaches inside the configured
   tolerance are retained and audited without weakening product or lifecycle constraints.

--- a/optimalportfolios/tests/root_import_cycle_test.py
+++ b/optimalportfolios/tests/root_import_cycle_test.py
@@ -1,0 +1,67 @@
+"""
+Library modules do not import the top-level ``optimalportfolios`` package at module scope.
+
+``optimalportfolios/__init__.py`` star-imports subpackages in sequence. A library module that
+imports through that package root can therefore re-enter a partially initialized module, and
+whether the requested name is already bound depends on the order of those star imports.
+
+Examples and tests are excluded because they intentionally exercise the public package API.
+Function- and method-local imports are also allowed: they execute only when the callable runs,
+after normal package initialization. Imports nested in module-level control flow remain covered
+because they still execute while the module is imported.
+"""
+# packages
+import ast
+from pathlib import Path
+from typing import Iterator, List, Tuple
+# optimalportfolios
+import optimalportfolios
+
+PACKAGE_ROOT: Path = Path(optimalportfolios.__file__).parent
+PACKAGE_NAME: str = optimalportfolios.__name__
+EXCLUDED_PARTS: Tuple[str, ...] = ('examples', 'tests', 'notebooks')
+
+
+def _walk_module_scope(node: ast.AST) -> Iterator[ast.AST]:
+    """Yield nodes outside function, method, and class scopes."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+        return
+    yield node
+    for child in ast.iter_child_nodes(node):
+        yield from _walk_module_scope(child)
+
+
+def find_root_package_imports() -> List[str]:
+    """Return module-scope imports of the top-level package in library modules."""
+    offenders = []
+    for path in sorted(PACKAGE_ROOT.rglob('*.py')):
+        if any(part in EXCLUDED_PARTS for part in path.parts):
+            continue
+        if path.name.endswith(('_test.py', '_tests.py')) or path.name == '__init__.py':
+            continue
+        tree = ast.parse(path.read_text(encoding='utf-8'))
+        rel = path.relative_to(PACKAGE_ROOT.parent).as_posix()
+        for node in _walk_module_scope(tree):
+            if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module == PACKAGE_NAME:
+                names = ', '.join(alias.name for alias in node.names)
+                offenders.append(f"{rel}:{node.lineno}: from {PACKAGE_NAME} import {names}")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == PACKAGE_NAME:
+                        as_part = f" as {alias.asname}" if alias.asname else ''
+                        offenders.append(f"{rel}:{node.lineno}: import {PACKAGE_NAME}{as_part}")
+    return offenders
+
+
+def test_no_library_module_imports_the_root_package() -> None:
+    """Module-scope root imports must not create initialization-order cycles."""
+    offenders = find_root_package_imports()
+    assert not offenders, (
+        "library module imports the top-level package at module scope; import the defining "
+        "module instead:\n" + '\n'.join(offenders)
+    )
+
+
+if __name__ == '__main__':
+    for offender in find_root_package_imports():
+        print(offender)


### PR DESCRIPTION
Lands the already verified S13 guard commit 9aa7ad9 unchanged, preserving it as an ancestor of main. This is the S15-approved fallback for PR #22.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a regression test to prevent module-scope imports of the top-level package within library modules.</li>
<li>Updated CHANGELOG.md to document the addition of the root-package import-cycle guard.</li>
</ul></div>