### PR TITLE
Integrate S15 Part A dependency hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   tolerance are retained and audited without weakening product or lifecycle constraints.
 
 ### Changed
+- The S&P 500 span comparison example now uses the project-local output-path helper instead of
+  the undeclared private `quant_strats` package, resolving issue #27.
+- The Bloomberg S&P 500 universe example now raises an actionable, exception-chained installation
+  message when `bbg-fetch` is unavailable, resolving issue #27.
 - Covariance factorization is now owned exclusively by each low-level CVXPY solver. Wrappers pass
   only `factorize_covar`; solver APIs no longer accept a precomputed factorization, and
   `resolve_covariance_factorization` has been removed. Each enabled solve calls
@@ -23,6 +27,14 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `validate_solution` now always returns `OptimizationOutcome`. Its legacy tuple return and
   `return_outcome` switch were removed; validated weights and acceptance state are available as
   `outcome.weights` and `outcome.accepted`.
+
+### Removed
+- Removed the unused `plotly` dependency and `visualization` extra because no shipped package code
+  imports Plotly, resolving issue #27.
+- Removed `pandas-datareader` from the `data` extra because no shipped package code imports it,
+  resolving issue #27.
+- Removed the direct `jinja2` declaration because `pybloqs` already installs it transitively,
+  resolving issue #27.
 
 ## [6.11.0] - 2026-08-09
 

--- a/optimalportfolios/examples/comparisons/sp500_minvar_spans.py
+++ b/optimalportfolios/examples/comparisons/sp500_minvar_spans.py
@@ -83,7 +83,7 @@ class LocalTests(Enum):
 def run_local_test(local_test: LocalTests):
     """Run local tests for product_development and debugging purposes."""
 
-    import quant_strats.local_path as lp
+    import optimalportfolios.local_path as lp
     from optimalportfolios.examples.data.sp500_universe import load_sp500_universe_yahoo
 
     if local_test == LocalTests.CROSS_BACKTEST:

--- a/optimalportfolios/examples/data/sp500_universe.py
+++ b/optimalportfolios/examples/data/sp500_universe.py
@@ -105,7 +105,13 @@ def create_sp500_universe_with_bloomberg(start_date: pd.Timestamp = pd.Timestamp
         start_date: Start date for time series universe. Defaults to Dec 31, 1995.
         local_path: Path to directory for saving CSV files. Defaults to LOCAL_PATH.
     """
-    from bbg_fetch import fetch_field_timeseries_per_tickers, fetch_fundamentals
+    try:
+        from bbg_fetch import fetch_field_timeseries_per_tickers, fetch_fundamentals
+    except ImportError as exc:
+        raise ImportError(
+            "create_sp500_universe_with_bloomberg needs bbg-fetch and a live Bloomberg "
+            "terminal: pip install bbg-fetch"
+        ) from exc
     inclusion_indicators, inclusion_indicators_bbg = create_inclusion_indicators()
 
     tickers = inclusion_indicators_bbg.columns.to_list()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,16 +59,10 @@ dependencies = [
 [project.optional-dependencies]
 data = [
     "yfinance>=0.2.40",
-    "pandas-datareader>=0.10.0",
 ]
 
 reports = [
     "pybloqs>=1.2.13",
-    "jinja2>=3.0.0",
-]
-
-visualization = [
-    "plotly>=5.0.0",
 ]
 
 docs = [
@@ -98,7 +92,7 @@ dev = [
 ]
 
 all = [
-    "optimalportfolios[data,reports,visualization,jupyter,clustering]",
+    "optimalportfolios[data,reports,jupyter,clustering]",
 ]
 
 [project.urls]


### PR DESCRIPTION
Lands verified Part A commit d887d5b on the post-PR #23 main line. Preserves the TID253 bans, removes only the three approved dependency declarations, and retains the validated example import guards.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored S&P 500 span comparison example to use project-local path helper instead of an undeclared private package.</li>
<li>Improved error handling in Bloomberg S&P 500 universe data loading by adding an actionable installation message when bbg-fetch is missing.</li>
<li>Cleaned up project dependencies by removing unused packages: plotly, pandas-datareader, and direct jinja2 declaration.</li>
<li>Updated optional dependencies and the 'all' extra in pyproject.toml to reflect the removal of unused packages.</li>
</ul></div>