### PR TITLE
Rename the last test-named module that collects no tests (closes #18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,9 @@ optimalportfolios/
 papers/              code accompanying the published papers (excluded from ruff)
 ```
 
-Tests live inside the package as `optimalportfolios/<subpackage>/tests/*_test.py`; there is no top-level `tests/` directory. Fifteen `*_local.py` files are `run_local_test` diagnostic dispatchers: run them manually when the required local price data is available; pytest never collects them, and the test suite is exactly what bare `pytest` collects.
+Tests live inside the package as `optimalportfolios/<subpackage>/tests/*_test.py`; there is no top-level `tests/` directory. Sixteen `*_local.py` files are `run_local_test` diagnostic dispatchers: run them manually when the required local price data is available; pytest never collects them, and the test suite is exactly what bare `pytest` collects. The sixteenth is `examples/data/etf_prices_local.py`, which is also the shared loader those dispatchers import their price panel from.
+
+Every file matching pytest's default patterns — `*_test.py` **and** `test_*.py` — collects at least one test, so the file count is a usable proxy for the suite. Keep it that way: a new diagnostic script belongs in `*_local.py`, not under a test-shaped name. A name matching either pattern is *imported* at collection even when it contributes no tests, which is how a module-level import of an optional extra has twice broken CI.
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   tolerance are retained and audited without weakening product or lifecycle constraints.
 
 ### Changed
+- `examples/data/test_data.py` is renamed to `examples/data/etf_prices_local.py`. It matched
+  pytest's `test_*.py` pattern, so it was imported at collection while contributing no tests —
+  the mechanism behind two past CI failures from module-level optional-extra imports. The
+  `load_test_data` and `update_test_prices` functions are unchanged; only the module path moves,
+  and the six `*_local.py` diagnostics that import it are updated. Every file matching either of
+  pytest's default patterns now collects at least one test.
 - Covariance factorization is now owned exclusively by each low-level CVXPY solver. Wrappers pass
   only `factorize_covar`; solver APIs no longer accept a precomputed factorization, and
   `resolve_covariance_factorization` has been removed. Each enabled solve calls

--- a/optimalportfolios/alphas/signals/tests/signals_local.py
+++ b/optimalportfolios/alphas/signals/tests/signals_local.py
@@ -34,7 +34,7 @@ def run_local_test(local_test: LocalTests):
     pd.set_option('display.max_columns', 500)
     pd.set_option('display.width', 1000)
 
-    from optimalportfolios.examples.data.test_data import load_test_data
+    from optimalportfolios.examples.data.etf_prices_local import load_test_data
     prices = load_test_data()
     prices = prices.loc['2005':, :]
     tickers = prices.columns.to_list()

--- a/optimalportfolios/covar_estimation/tests/ewma_covar_estimator_local.py
+++ b/optimalportfolios/covar_estimation/tests/ewma_covar_estimator_local.py
@@ -27,7 +27,7 @@ def run_local_test(local_test: LocalTests):
     pd.set_option('display.max_columns', 500)
     pd.set_option('display.width', 1000)
 
-    from optimalportfolios.examples.data.test_data import load_test_data
+    from optimalportfolios.examples.data.etf_prices_local import load_test_data
     prices = load_test_data()
     prices = prices.loc['2000':, :]
     tickers = prices.columns.to_list()

--- a/optimalportfolios/covar_estimation/tests/factor_covar_estimator_local.py
+++ b/optimalportfolios/covar_estimation/tests/factor_covar_estimator_local.py
@@ -29,7 +29,7 @@ def run_local_test(local_test: LocalTests):
     pd.set_option('display.max_columns', 500)
     pd.set_option('display.width', 1000)
 
-    from optimalportfolios.examples.data.test_data import load_test_data
+    from optimalportfolios.examples.data.etf_prices_local import load_test_data
     prices = load_test_data()
     prices = prices.loc['2000':, :]
     tickers = prices.columns.to_list()

--- a/optimalportfolios/examples/data/etf_prices_local.py
+++ b/optimalportfolios/examples/data/etf_prices_local.py
@@ -1,6 +1,14 @@
-"""
-implement test universe for optimisations
-use update and save universe for speed-up of test cases
+"""the eight-ETF cross-asset universe the local diagnostics run on.
+
+Both halves of this module need the author's machine: ``update_test_prices`` downloads from
+Yahoo, and ``load_test_data`` reads the saved panel out of ``RESOURCE_PATH``. Neither is
+reachable in CI, and nothing here asserts anything.
+
+Hence the ``_local`` suffix. The file was called ``test_data.py`` and so matched pytest's
+``test_*.py`` pattern: it collected no tests but was still *imported* at collection time,
+which is the mechanism behind the two CI failures a module-level ``yfinance`` import has
+already caused here. The ``yfinance`` import is function-local below, but the naming is what
+made that a rule to remember rather than a property of the layout.
 """
 
 # imports

--- a/optimalportfolios/optimization/tests/max_diversification_local.py
+++ b/optimalportfolios/optimization/tests/max_diversification_local.py
@@ -83,7 +83,7 @@ def run_local_test(local_test: LocalTests):
 
     elif local_test == LocalTests.MAX_DIVERSIFICATION_ROLLING:
         import qis as qis
-        from optimalportfolios.examples.data.test_data import load_test_data
+        from optimalportfolios.examples.data.etf_prices_local import load_test_data
         prices = load_test_data()
         prices = prices.loc['2000':, :]
 

--- a/optimalportfolios/optimization/tests/risk_budgeting_local.py
+++ b/optimalportfolios/optimization/tests/risk_budgeting_local.py
@@ -191,7 +191,7 @@ def run_local_test(local_test: LocalTests):
 
     elif local_test == LocalTests.ROLLING_RISK_BUDGETING:
         import qis as qis
-        from optimalportfolios.examples.data.test_data import load_test_data
+        from optimalportfolios.examples.data.etf_prices_local import load_test_data
         from optimalportfolios.covar_estimation.ewma_covar_estimator import EwmaCovarEstimator
 
         prices = load_test_data()

--- a/optimalportfolios/utils/tests/gaussian_mixture_local.py
+++ b/optimalportfolios/utils/tests/gaussian_mixture_local.py
@@ -73,7 +73,7 @@ def run_local_test(local_test: LocalTests):
         plot_mixure2(x)
 
     elif local_test == LocalTests.ROLLING_FIT:
-        from optimalportfolios.examples.data.test_data import load_test_data
+        from optimalportfolios.examples.data.etf_prices_local import load_test_data
         prices = load_test_data()
         prices = prices.loc['2000':, :]  # have at least 3 assets
         prices = prices['SPY'].dropna()


### PR DESCRIPTION
Closes #18.

## What was left

`optimalportfolios/examples/data/test_data.py` matched pytest's *other* default pattern, `test_*.py`. [JOSS S8] swept the `*_test.py` suffix form and renamed 15 dispatchers to `*_local.py`; this one survived because the check at the time matched only the suffix.

It contributed zero tests but was still **imported at collection time** — consequence 2 of the original finding, and the mechanism behind the two CI failures a module-level `yfinance` import has already caused in this repo. It survived in the module that downloads the price fixture, which is the one place that matters most.

## What changed

`examples/data/test_data.py` → `examples/data/etf_prices_local.py`.

The naming was the judgement call the issue flagged, since the file is both a `run_local_test` dispatcher and the shared loader six `*_local.py` diagnostics import from. `_local` wins because both halves need the author's machine: `update_test_prices` downloads from Yahoo, `load_test_data` reads out of `RESOURCE_PATH`. Neither is reachable in CI. The module docstring now states that, and states why the name matters.

`load_test_data` and `update_test_prices` are unchanged, and were never exported from the package — only the six import paths move.

## Verification

The mechanism, not just the outcome. Appending a `raise` and running `pytest --collect-only`:

- before — `ERROR collecting optimalportfolios/examples/data/test_data.py` / `RuntimeError: PYTEST_IMPORTED_THIS_FILE`
- after — no error; pytest never imports it

The issue's "done when" is now a one-line check, and it passes: **27 files match either default pattern, and all 27 collect at least one test.**

`AGENTS.md` now states that invariant rather than only the file count — the count is what drifted last time — and names both patterns, since matching either is what causes the import.

## Gates

| | 3.10 / pandas 2.3.3 | 3.11 / pandas 3.0.5 |
|---|---|---|
| pytest | 632 passed | 632 passed |

`ruff` stack invariants (TID251/TID253/ICN) green; `interrogate` at 100%.

## Note on scope

This is independent of #23 (the coverage work) and branches off `main`, so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)