### PR TITLE
Run the test jobs on all three OSes, and gate pre-commit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,36 @@ jobs:
     - name: Check stack invariants and the F family
       run: ruff check --select TID251,TID253,ICN,F optimalportfolios/
 
+  pre-commit:
+    # Runs every hook in .pre-commit-config.yaml over the whole repository, so the
+    # local hooks cannot silently rot: a contributor who never ran `pre-commit
+    # install`, or whose hook revs drifted, still fails here.
+    #
+    # --all-files rather than the staged set, because a workflow run has no staged
+    # set and the hooks are cheap enough (ruff, interrogate and file checks) to
+    # sweep the repository each time.
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: "3.12"
+
+    - name: Install pre-commit
+      run: |
+        python -m pip install --upgrade pip
+        # Pin the current 4.x series, as the lint and audit jobs pin their tools, so
+        # a pre-commit release cannot change the verdict on an unchanged repository.
+        pip install "pre-commit~=4.4"
+
+    - name: Run every hook
+      # show-diff-on-failure turns a rewriting hook's failure into a readable patch
+      # in the log, rather than a bare "files were modified by this hook".
+      run: pre-commit run --all-files --show-diff-on-failure
+
   test:
     # The suite is pure-Python and NaN-aware pandas, but the scientific stack ships
     # per-platform wheels and pandas frequency/locale behaviour has bitten this kind of

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,14 @@ jobs:
       run: ruff check --select TID251,TID253,ICN,F optimalportfolios/
 
   test:
-    runs-on: ubuntu-latest
+    # The suite is pure-Python and NaN-aware pandas, but the scientific stack ships
+    # per-platform wheels and pandas frequency/locale behaviour has bitten this kind of
+    # code before, so the matrix runs every supported Python on all three runners.
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
@@ -61,6 +65,9 @@ jobs:
         pip install -e ".[dev]"
 
     - name: Verify imports
+      # bash on every runner: the default shell on windows-latest is PowerShell, which
+      # parses this multi-line quoted argument differently.
+      shell: bash
       run: |
         python -c "
         from optimalportfolios import (
@@ -71,6 +78,7 @@ jobs:
         "
 
     - name: Verify factorlasso integration
+      shell: bash
       run: |
         python -c "
         from factorlasso import LassoModel as FL_LassoModel
@@ -83,11 +91,15 @@ jobs:
       # The floor lives in [tool.coverage.report] fail_under in pyproject.toml, so this job
       # fails when coverage regresses below it. term-missing prints the uncovered lines, which
       # is what a contributor needs to act on the failure without re-running locally.
-      if: matrix.python-version == '3.12'
+      #
+      # Measured on ubuntu/3.12 only, so the floor keeps one authoritative number. A
+      # platform-specific skip on another runner would otherwise fail the gate there for
+      # a reason that has nothing to do with coverage regressing.
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
       run: pytest --cov=optimalportfolios --cov-report=term-missing
 
     - name: Run the test suite
-      if: matrix.python-version != '3.12'
+      if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.12'
       run: pytest
 
   docstrings:
@@ -152,7 +164,11 @@ jobs:
     # data, network or a Bloomberg terminal. Without this job the constraint is
     # a convention, and it has already been broken twice by a module-scope
     # yfinance import.
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -169,6 +185,7 @@ jobs:
         pip install pytest
 
     - name: Assert the optional extras are absent
+      shell: bash
       run: |
         python -c "
         import importlib.util

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 # YAML
 *.yaml
 !.readthedocs.yaml
+!.pre-commit-config.yaml
 
 # Byte-compiled / optimized / DLL files
 docs/figures/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+# Local mirror of the CI gates in .github/workflows/ci.yml, so a push fails at commit
+# time rather than on the runner. Install with:
+#
+#     pip install pre-commit && pre-commit install
+#
+# Run over the whole repository once with `pre-commit run --all-files`.
+
+# papers/ reproduces published results and is deliberately excluded from linting;
+# ruff and interrogate exclude it in pyproject.toml too, and this keeps the file
+# hooks off it as well.
+exclude: '^papers/'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      # Check-only, never rewrite. The package carries ~380 E501 and a handful of
+      # W291/W292 findings that AGENTS.md asks be left alone, so a whitespace fixer
+      # would reflow unrelated lines of any legacy file a change happens to touch.
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        # Backtest outputs and factsheets must never reach version control.
+        args: ["--maxkb=500"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Within the `ruff~=0.16.0` series the lint job pins, so local and CI agree.
+    rev: v0.16.2
+    hooks:
+      - id: ruff-check
+        # Exactly the CI selection: the three stack invariants (TID251, TID253, ICN)
+        # plus the F family. E/W stay out because of the legacy E501 backlog.
+        #
+        # No --fix on purpose. F401 in an __init__.py is a re-export, and autofixing
+        # it would delete the public surface of every subpackage.
+        args: ["--select", "TID251,TID253,ICN,F"]
+
+  - repo: https://github.com/econchick/interrogate
+    rev: 1.7.0
+    hooks:
+      - id: interrogate
+        # fail-under = 100 and the papers/ exclusion live in [tool.interrogate] in
+        # pyproject.toml. Coverage is a whole-package number, so this runs over the
+        # package rather than the staged files.
+        args: ["-v"]
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,10 +69,10 @@ interrogate                                              # docstring coverage, m
 
 *Note: Terminal execution should be compatible with Windows PowerShell within PyCharm.*
 
-Optional extras: `data`, `reports`, `clustering`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Separate jobs gate the three ruff stack invariants, `interrogate` docstring coverage at 100%, and `pip-audit` over the dependency tree resolved from `pyproject.toml`. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
+Optional extras: `data`, `reports`, `clustering`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Both of those jobs run on `ubuntu-latest`, `windows-latest` and `macos-latest`, so a fix that only holds on POSIX paths or POSIX line endings fails the matrix. Separate jobs gate the three ruff stack invariants, `interrogate` docstring coverage at 100%, and `pip-audit` over the dependency tree resolved from `pyproject.toml`. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
 
-Full-package line coverage measured **89.70%** on the 1111-test dev suite. The Python 3.12
-matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 88`; this floor rises
+Full-package line coverage measured **89.70%** on the 1111-test dev suite. The
+ubuntu/3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 88`; this floor rises
 whenever measured coverage rises, and lowering it requires a dated `CHANGELOG.md` note.
 Measure on a `[dev]` install: a core install lacks the `clustering` extra, so the `mcf` cases
 skip and the total lands below the floor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ pytest                                                   # run the test suite (1
 pytest optimalportfolios/optimization/tests/constraints_test.py -v
 ruff check optimalportfolios/                            # lint (papers/ is excluded)
 interrogate                                              # docstring coverage, must stay at 100%
+pre-commit install                                       # once per clone, wires up the git hook
+pre-commit run --all-files                               # the same gates CI runs
 ```
 
 *Note: Terminal execution should be compatible with Windows PowerShell within PyCharm.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.4",
     "interrogate>=1.7",
+    # runs the hooks in .pre-commit-config.yaml; `pre-commit install` still has to be
+    # run once per clone to wire up the git hook itself.
+    "pre-commit>=4.0",
     "optimalportfolios[data,clustering]",
 ]
 


### PR DESCRIPTION
Two related CI changes.

## 1. The test jobs run on ubuntu, windows and macos

The suite only ever ran on `ubuntu-latest`, so a POSIX-only assumption — a path separator, a line ending, a temp-directory lifetime — could land green and break for a contributor on another platform.

- **`test`** gains `os: [ubuntu-latest, windows-latest, macos-latest]`, crossed with the existing 3.10–3.13 → 12 cells. `fail-fast: false` was already set.
- **`core-install`** (which also runs `pytest`, on a no-extras install) runs on the same three runners → 3 cells.
- `lint`, `docstrings` and `audit` stay on `ubuntu-latest` — they read source and `pyproject.toml`, so triplicating them buys identical verdicts.

**The coverage gate stays single-platform**, now `matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'`, so `fail_under = 88` keeps one authoritative number — a platform-specific skip elsewhere would otherwise fail the gate for a reason unrelated to coverage regressing. The plain `pytest` step's condition is the exact complement, so every cell runs the suite exactly once.

**The three `python -c "…"` steps get `shell: bash`.** The default shell on `windows-latest` is PowerShell, which parses those multi-line quoted arguments differently.

All 15 cells passed on the first run — the suite is platform-clean as-is, no source changes needed.

## 2. A pre-commit config, gated in CI

`.pre-commit-config.yaml` mirrors the existing CI gates rather than introducing a second standard: the `pre-commit-hooks` file checks, `ruff-check` with exactly `--select TID251,TID253,ICN,F` pinned inside the `ruff~=0.16.0` series the lint job uses, and `interrogate` reading `fail-under = 100` from `pyproject.toml`. `papers/` is excluded throughout.

Two deliberate omissions:

- **No `--fix` on ruff.** `F401` in an `__init__.py` is a re-export; autofixing it would delete the public surface of every subpackage.
- **No whitespace fixers.** The legacy modules carry ~380 `E501` and a handful of `W291`/`W292` findings that AGENTS.md asks be left alone, and a fixer would reflow unrelated lines of any file a change happens to touch.

A new **`pre-commit` job** runs every hook over the whole repository, so the local hooks cannot rot: a contributor who never ran `pre-commit install`, or whose revs drifted, still fails in CI.

### `.gitignore` needed a negation

A blanket `*.yaml` rule at `.gitignore:14` meant `.pre-commit-config.yaml` existed on disk but never appeared in `git status` — it would have been invisible to CI and to every contributor. Fixed with `!.pre-commit-config.yaml`, the same shape as the `!.readthedocs.yaml` line above it.

*Unrelated but noticed: that same rule also excludes `optimalportfolios/settings.yaml`, which AGENTS.md lists as part of the layout. Left alone here.*

## Verification

- First CI run: **all 15 matrix cells green**, plus lint, docstrings and audit.
- `pre-commit run --all-files`: six hooks green on the real tree.
- `interrogate -v` from root: 1635 nodes, 100.0%, `papers/` excluded.
- The gates actually fire — a temporary probe module with a banned `trendfollowing` import, a module-level `yfinance`, `import numpy as numpy_wrong` and an undefined name produced TID251, TID253, ICN001 and F821 respectively. Probe deleted.

## Note for the reviewer

The `lint` and `docstrings` jobs now duplicate what the `pre-commit` job runs. Left in place — they give a sharper failure label — but they are collapsible if you'd rather not pay for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)