### PR TITLE
Land the multi-OS test matrix from PR #40

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,14 @@ jobs:
       run: ruff check --select TID251,TID253,ICN,F optimalportfolios/
 
   test:
-    runs-on: ubuntu-latest
+    # The suite is pure-Python and NaN-aware pandas, but the scientific stack ships
+    # per-platform wheels and pandas frequency/locale behaviour has bitten this kind of
+    # code before, so the matrix runs every supported Python on all three runners.
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
@@ -61,6 +65,9 @@ jobs:
         pip install -e ".[dev]"
 
     - name: Verify imports
+      # bash on every runner: the default shell on windows-latest is PowerShell, which
+      # parses this multi-line quoted argument differently.
+      shell: bash
       run: |
         python -c "
         from optimalportfolios import (
@@ -71,6 +78,7 @@ jobs:
         "
 
     - name: Verify factorlasso integration
+      shell: bash
       run: |
         python -c "
         from factorlasso import LassoModel as FL_LassoModel
@@ -83,11 +91,15 @@ jobs:
       # The floor lives in [tool.coverage.report] fail_under in pyproject.toml, so this job
       # fails when coverage regresses below it. term-missing prints the uncovered lines, which
       # is what a contributor needs to act on the failure without re-running locally.
-      if: matrix.python-version == '3.12'
+      #
+      # Measured on ubuntu/3.12 only, so the floor keeps one authoritative number. A
+      # platform-specific skip on another runner would otherwise fail the gate there for
+      # a reason that has nothing to do with coverage regressing.
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
       run: pytest --cov=optimalportfolios --cov-report=term-missing
 
     - name: Run the test suite
-      if: matrix.python-version != '3.12'
+      if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.12'
       run: pytest
 
   docstrings:
@@ -152,7 +164,11 @@ jobs:
     # data, network or a Bloomberg terminal. Without this job the constraint is
     # a convention, and it has already been broken twice by a module-scope
     # yfinance import.
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -169,6 +185,7 @@ jobs:
         pip install pytest
 
     - name: Assert the optional extras are absent
+      shell: bash
       run: |
         python -c "
         import importlib.util

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Every file matching pytest's default patterns — `*_test.py` **and** `test_*.py
 
 ```bash
 pip install -e ".[dev]"                                  # editable install with dev tools
-pytest                                                   # run the test suite (1111 tests, ~60 s)
+pytest                                                   # run the test suite (1114 tests, ~60 s)
 pytest optimalportfolios/optimization/tests/constraints_test.py -v
 ruff check optimalportfolios/                            # lint (papers/ is excluded)
 interrogate                                              # docstring coverage, must stay at 100%
@@ -69,10 +69,10 @@ interrogate                                              # docstring coverage, m
 
 *Note: Terminal execution should be compatible with Windows PowerShell within PyCharm.*
 
-Optional extras: `data`, `reports`, `clustering`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Separate jobs gate the three ruff stack invariants, `interrogate` docstring coverage at 100%, and `pip-audit` over the dependency tree resolved from `pyproject.toml`. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
+Optional extras: `data`, `reports`, `clustering`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Both of those jobs run on `ubuntu-latest`, `windows-latest` and `macos-latest`, so a fix that only holds on POSIX paths or POSIX line endings fails the matrix. Separate jobs gate the three ruff stack invariants, `interrogate` docstring coverage at 100%, and `pip-audit` over the dependency tree resolved from `pyproject.toml`. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
 
-Full-package line coverage measured **89.70%** on the 1111-test dev suite. The Python 3.12
-matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 88`; this floor rises
+Full-package line coverage measured **89.70%** on the 1114-test dev suite. The
+ubuntu/3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 88`; this floor rises
 whenever measured coverage rises, and lowering it requires a dated `CHANGELOG.md` note.
 Measure on a `[dev]` install: a core install lacks the `clustering` extra, so the `mcf` cases
 skip and the total lands below the floor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- CI test jobs now run on ubuntu-latest, windows-latest and macos-latest across Python
+  3.10–3.13, adopted from PR #40 by @tschm; the coverage gate remains ubuntu + Python 3.12.
+
 ## [6.14.0] - 2026-08-11
 
 **Risk-label behaviour change:** the default full-panel lineage matcher now enforces the lower


### PR DESCRIPTION
Credits @tschm for the original implementation in PR #40 and preserves that authorship in the integration commit.

Implements the matrix-only disposition in roadmap/S20_PR40_CLOSEOUT_STAGE.md:
- dev tests run on ubuntu-latest, windows-latest, and macos-latest across Python 3.10-3.13;
- core-install tests run on all three operating systems;
- coverage remains the single ubuntu-latest / Python 3.12 authority at the unchanged floor;
- all Action references remain SHA-pinned;
- the bundled pre-commit configuration, CI job, ignore change, and dependency are deliberately excluded.

Local verification: workflow YAML parsed; 1,114 tests passed; Ruff gate clean; Interrogate 100%; coverage 89.69% against floor 88%.