### PR TITLE
Fix plot_current_covar_data for factorlasso's flat cluster fields (closes #45)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Every file matching pytest's default patterns — `*_test.py` **and** `test_*.py
 
 ```bash
 pip install -e ".[dev]"                                  # editable install with dev tools
-pytest                                                   # run the test suite (1142 tests, ~60 s)
+pytest                                                   # run the test suite (1145 tests, ~60 s)
 pytest optimalportfolios/optimization/tests/constraints_test.py -v
 ruff check optimalportfolios/                            # lint (papers/ is excluded)
 interrogate                                              # docstring coverage, must stay at 100%
@@ -76,7 +76,7 @@ interrogate                                              # docstring coverage, m
 
 Optional extras: `data`, `reports`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Both of those jobs run on `ubuntu-latest`, `windows-latest` and `macos-latest`, so a fix that only holds on POSIX paths or POSIX line endings fails the matrix. The ubuntu/Python 3.12 coverage cell alone installs against `constraints.txt`, regenerated at each release; the remaining matrix cells, core installs and audit resolution deliberately float. Separate jobs gate the three ruff stack invariants, `interrogate` docstring coverage at 100%, and `pip-audit` over the dependency tree resolved from `pyproject.toml`. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
 
-Line coverage measured **96.12%** on the 1142-test dev suite. The
+Line coverage measured **96.18%** on the 1145-test dev suite. The
 ubuntu/3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 95`; this floor rises
 whenever measured coverage rises, and lowering it requires a dated `CHANGELOG.md` note.
 The measured scope is not the whole package: `[tool.coverage.run] omit` drops `reports/` alongside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ alongside `tests/`, `examples/` and `papers/`. The reporting layer renders facts
 `qis` and `pybloqs` and is reviewed by eye rather than by assertion; measured at 3.9% it
 contributed 223 of the 597 missed lines and did nothing but dilute the ratchet. Anything with
 a numerical contract belongs outside `reports/`, where it is still measured. The floor rises
-from `fail_under = 88` to `95`: measured coverage over the narrowed scope is 96.12%, up from
-92.99% at the moment of the scope change, on a suite grown from 1077 to 1142 tests.
+from `fail_under = 88` to `95`: measured coverage over the narrowed scope is 96.18%, up from
+92.99% at the moment of the scope change, on a suite grown from 1077 to 1145 tests.
 
 ### Added
 
@@ -23,16 +23,11 @@ from `fail_under = 88` to `95`: measured coverage over the narrowed scope is 96.
   the CVXPY covariance stabiliser (`optimization/covar_factorization.py`), and the
   settings-path accessors (`local_path.py`).
 
-### Known issues
+### Fixed
 
-- `covar_estimation.covar_reporting.plot_current_covar_data` raises `NotImplementedError` for
-  any universe of more than two assets, and `run_rolling_covar_report(is_plot=True)` inherits
-  the failure. The function forwards `CurrentFactorCovarData.clusters` / `.linkages` /
-  `.cutoffs` into `plot_clusters`, which expects one entry per *cadence*; since factorlasso
-  moved those fields to a flat `pd.Series` / `pd.DataFrame` keyed by asset, the cadence count
-  is read as the asset count. Surfaced by the first test ever to run the path and pinned as a
-  strict `xfail` in `covar_estimation/tests/covar_reporting_test.py`; not fixed here, since
-  repairing the adapter is a behaviour change rather than a test addition.
+- Reconstructed factorlasso's flat, persisted cluster/linkage/cutoff fields by cadence before
+  plotting, so `plot_current_covar_data` and `run_rolling_covar_report(is_plot=True)` render
+  multi-asset universes again. The defect was discovered by @tschm in PR #44.
 
 ## [6.16.0] - 2026-08-12
 

--- a/optimalportfolios/covar_estimation/covar_reporting.py
+++ b/optimalportfolios/covar_estimation/covar_reporting.py
@@ -19,7 +19,12 @@ from qis.plots.utils import get_table_lines_for_group_data, set_title, set_supti
 from matplotlib.colors import ListedColormap
 from typing import List, Dict, Tuple, Optional, Union
 
-from factorlasso import CurrentFactorCovarData
+from factorlasso import (
+    CurrentFactorCovarData,
+    get_clusters_by_freq,
+    get_cutoffs_by_freq,
+    get_linkages_by_freq,
+)
 from optimalportfolios.covar_estimation.factor_covar_estimator import FactorCovarEstimator
 
 def plot_current_covar_data(covar_data: CurrentFactorCovarData,
@@ -28,6 +33,9 @@ def plot_current_covar_data(covar_data: CurrentFactorCovarData,
 
     """Plot the HCGL diagnostics of one covariance snapshot."""
     df = covar_data.get_snapshot()
+    clusters = get_clusters_by_freq(covar_data.clusters)
+    linkages = get_linkages_by_freq(covar_data.linkages)
+    cutoffs = get_cutoffs_by_freq(covar_data.cutoffs)
     figs = plot_hcgl_covar_data(x_covar=covar_data.x_covar,
                                 y_covar=covar_data.y_covar,
                                 betas=covar_data.y_betas,
@@ -35,9 +43,9 @@ def plot_current_covar_data(covar_data: CurrentFactorCovarData,
                                 total_vol=df['total_vol'],
                                 residual_vol=df['resid_vol'],
                                 alpha=df['stat_alpha'],
-                                clusters=covar_data.clusters,
-                                linkages=covar_data.linkages,
-                                cutoffs=covar_data.cutoffs,
+                                clusters=clusters,
+                                linkages=linkages,
+                                cutoffs=cutoffs,
                                 date=covar_data.estimation_date,
                                 **kwargs)
     return figs

--- a/optimalportfolios/covar_estimation/tests/covar_reporting_test.py
+++ b/optimalportfolios/covar_estimation/tests/covar_reporting_test.py
@@ -15,10 +15,9 @@ returned aggregate cluster series rather than inspecting pixels.
 those two cases -- and raises otherwise; that guard is the difference between an exception and
 an IndexError three frames deeper.
 
-One path here is currently broken and is pinned as a strict xfail rather than hidden:
-``plot_current_covar_data`` unpacks ``CurrentFactorCovarData`` as though its cluster fields
-were per-cadence dicts, which they have not been since factorlasso moved them to a flat
-Series/DataFrame. See ``test_plot_current_covar_data_is_broken_against_the_factorlasso_shape``.
+The snapshot adapter is checked against factorlasso's flat persisted cluster fields. Its
+plotting inputs are also compared with an independent split of the raw factorlasso output so
+the rendered cadence assignments cannot silently drift from the estimated result.
 """
 # packages
 import matplotlib.pyplot as plt
@@ -29,6 +28,7 @@ import qis
 import scipy.cluster.hierarchy as spc
 from factorlasso import LassoModel, LassoModelType
 # optimalportfolios
+import optimalportfolios.covar_estimation.covar_reporting as covar_reporting
 from optimalportfolios.covar_estimation.covar_reporting import (
     plot_clusters,
     plot_current_covar_data,
@@ -198,22 +198,47 @@ def test_near_zero_betas_are_blanked_rather_than_printed_as_zero(covar_data) -> 
 
 
 # --------------------------------------------------------------------------- #
-# the broken CurrentFactorCovarData adapter
+# the CurrentFactorCovarData adapter
 # --------------------------------------------------------------------------- #
-@pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                   reason="plot_current_covar_data passes CurrentFactorCovarData.clusters "
-                          "(a flat Series keyed by asset) into plot_clusters, which expects a "
-                          "cadence-keyed dict; len() is then the asset count, not the cadence "
-                          "count. Broken for any universe of more than two assets.")
-def test_plot_current_covar_data_is_broken_against_the_factorlasso_shape(covar_data) -> None:
-    """The snapshot adapter has not followed factorlasso's cluster-field shape.
+def test_plot_current_covar_data_handles_the_factorlasso_shape(covar_data) -> None:
+    """The snapshot adapter splits factorlasso's flat fields and renders all four figures."""
+    figs = plot_current_covar_data(covar_data=covar_data)
+    assert len(figs) == 4
+    assert all(isinstance(fig, plt.Figure) for fig in figs)
 
-    ``CurrentFactorCovarData`` declares ``clusters: Optional[pd.Series]``,
-    ``linkages: Optional[pd.DataFrame]`` and ``cutoffs: Optional[pd.Series]``, but this
-    function forwards them to a signature typed ``Dict[str, ...]`` per cadence. Pinned strict
-    so the xfail turns into a failure the moment the adapter is fixed.
-    """
-    plot_current_covar_data(covar_data=covar_data)
+
+def test_seeded_factorlasso_clusters_are_the_clusters_plotted(covar_data,
+                                                              monkeypatch) -> None:
+    """Compare plotted cadence assignments with an independent split of factorlasso output."""
+    y_covar_before = covar_data.y_covar.copy(deep=True)
+    y_betas_before = covar_data.y_betas.copy(deep=True)
+    raw_clusters = covar_data.clusters.dropna().astype(str)
+    expected = {}
+    for freq in covar_data.cutoffs.index:
+        prefix = f'{freq}:'
+        selected = raw_clusters[raw_clusters.str.startswith(prefix)]
+        expected[freq] = selected.str.slice(start=len(prefix))
+
+    plotted = {}
+    real_plot_clusters = covar_reporting.plot_clusters
+
+    def capture_plot_clusters(clusters, linkages, cutoffs, figsize=(14, 10)):
+        """Capture the adapter output while delegating the actual rendering."""
+        plotted.update({freq: values.copy() for freq, values in clusters.items()})
+        return real_plot_clusters(clusters=clusters, linkages=linkages,
+                                  cutoffs=cutoffs, figsize=figsize)
+
+    monkeypatch.setattr(covar_reporting, 'plot_clusters', capture_plot_clusters)
+    figs = covar_reporting.plot_current_covar_data(covar_data=covar_data)
+
+    assert len(raw_clusters) >= 8
+    assert len(figs) == 4
+    assert set(plotted) == set(expected)
+    pd.testing.assert_frame_equal(covar_data.y_covar, y_covar_before)
+    pd.testing.assert_frame_equal(covar_data.y_betas, y_betas_before)
+    for freq in expected:
+        pd.testing.assert_series_equal(plotted[freq].sort_index().astype(str),
+                                       expected[freq].sort_index(), check_names=False)
 
 
 # --------------------------------------------------------------------------- #
@@ -267,14 +292,13 @@ def test_the_rebalancing_frequency_can_be_overridden(panels: tuple,
     assert len(monthly) > len(quarterly)
 
 
-@pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                   reason="is_plot=True routes into the broken plot_current_covar_data adapter; "
-                          "see the snapshot xfail above for the shape mismatch")
-def test_the_rolling_report_cannot_currently_plot(panels: tuple,
-                                                  estimator: FactorCovarEstimator) -> None:
-    """The plotting branch of the rolling report inherits the snapshot adapter's breakage."""
+def test_the_rolling_report_can_plot(panels: tuple,
+                                     estimator: FactorCovarEstimator) -> None:
+    """The plotting branch renders four figures for every fitted snapshot."""
     factor_prices, asset_prices, returns = panels
     time_period = qis.TimePeriod(returns.index[-4], returns.index[-1])
-    run_rolling_covar_report(risk_factor_prices=factor_prices, prices=asset_prices,
-                             covar_estimator=estimator, time_period=time_period,
-                             asset_returns_dict={'ME': returns}, assets=ASSETS, is_plot=True)
+    figs, dfs = run_rolling_covar_report(risk_factor_prices=factor_prices, prices=asset_prices,
+                                         covar_estimator=estimator, time_period=time_period,
+                                         asset_returns_dict={'ME': returns}, assets=ASSETS,
+                                         is_plot=True)
+    assert len(figs) == 4 * len(dfs)


### PR DESCRIPTION
Repairs the plotting adapter for factorlasso 0.14's flat persisted cluster metadata without changing covariance estimation. Uses factorlasso's canonical frequency reconstruction helpers, converts the two strict regression xfails added in PR #44 into passing tests, and adds a seeded eight-asset independent assignment check. Discovery credited to @tschm via PR #44.\n\nCloses #45

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Fixed a bug in `plot_current_covar_data` and `run_rolling_covar_report` where multi-asset universes caused rendering failures due to a shape mismatch with `factorlasso` data.</li>
<li>Updated the covariance reporting adapter to reconstruct flat cluster, linkage, and cutoff fields by cadence before plotting.</li>
<li>Replaced strict `xfail` tests with functional tests that verify the adapter correctly handles the `factorlasso` data shape.</li>
<li>Updated documentation and changelog to reflect the fix and the increased test suite size.</li>
</ul></div>