### PR TITLE
Raise line coverage to 99.03% and the floor to 99

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Every file matching pytest's default patterns — `*_test.py` **and** `test_*.py
 
 ```bash
 pip install -e ".[dev]"                                  # editable install with dev tools
-pytest                                                   # run the test suite (1200 tests, ~100 s)
+pytest                                                   # run the test suite (1272 tests, ~160 s)
 pytest optimalportfolios/optimization/tests/constraints_test.py -v
 ruff check optimalportfolios/                            # lint (papers/ is excluded)
 interrogate                                              # docstring coverage, must stay at 100%
@@ -76,8 +76,8 @@ interrogate                                              # docstring coverage, m
 
 Optional extras: `data`, `reports`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Both of those jobs run on `ubuntu-latest`, `windows-latest` and `macos-latest`, so a fix that only holds on POSIX paths or POSIX line endings fails the matrix. The ubuntu/Python 3.12 coverage cell alone installs against `constraints.txt`, regenerated at each release; the remaining matrix cells, core installs and audit resolution deliberately float. Separate jobs gate the three ruff stack invariants, `interrogate` docstring coverage at 100%, and `pip-audit` over the dependency tree resolved from `pyproject.toml`. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
 
-Line coverage measured **98.31%** on the 1200-test dev suite. The
-ubuntu/3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 98`; this floor rises
+Line coverage measured **99.09%** on the 1272-test dev suite. The
+ubuntu/3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 99`; this floor rises
 whenever measured coverage rises, and lowering it requires a dated `CHANGELOG.md` note.
 The measured scope is not the whole package: `[tool.coverage.run] omit` drops `reports/` alongside
 `tests/`, `examples/` and `papers/`, because the reporting layer renders through `qis` and `pybloqs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Every file matching pytest's default patterns — `*_test.py` **and** `test_*.py
 
 ```bash
 pip install -e ".[dev]"                                  # editable install with dev tools
-pytest                                                   # run the test suite (1149 tests, ~2 min)
+pytest                                                   # run the test suite (1200 tests, ~100 s)
 pytest optimalportfolios/optimization/tests/constraints_test.py -v
 ruff check optimalportfolios/                            # lint (papers/ is excluded)
 interrogate                                              # docstring coverage, must stay at 100%
@@ -76,8 +76,8 @@ interrogate                                              # docstring coverage, m
 
 Optional extras: `data`, `reports`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Both of those jobs run on `ubuntu-latest`, `windows-latest` and `macos-latest`, so a fix that only holds on POSIX paths or POSIX line endings fails the matrix. The ubuntu/Python 3.12 coverage cell alone installs against `constraints.txt`, regenerated at each release; the remaining matrix cells, core installs and audit resolution deliberately float. Separate jobs gate the three ruff stack invariants, `interrogate` docstring coverage at 100%, and `pip-audit` over the dependency tree resolved from `pyproject.toml`. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
 
-Line coverage measured **96.10%** on the 1149-test dev suite. The
-ubuntu/3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 95`; this floor rises
+Line coverage measured **98.31%** on the 1200-test dev suite. The
+ubuntu/3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 98`; this floor rises
 whenever measured coverage rises, and lowering it requires a dated `CHANGELOG.md` note.
 The measured scope is not the whole package: `[tool.coverage.run] omit` drops `reports/` alongside
 `tests/`, `examples/` and `papers/`, because the reporting layer renders through `qis` and `pybloqs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Every file matching pytest's default patterns — `*_test.py` **and** `test_*.py
 
 ```bash
 pip install -e ".[dev]"                                  # editable install with dev tools
-pytest                                                   # run the test suite (1272 tests, ~160 s)
+pytest                                                   # run the test suite (1276 tests, ~3 min)
 pytest optimalportfolios/optimization/tests/constraints_test.py -v
 ruff check optimalportfolios/                            # lint (papers/ is excluded)
 interrogate                                              # docstring coverage, must stay at 100%
@@ -76,7 +76,7 @@ interrogate                                              # docstring coverage, m
 
 Optional extras: `data`, `reports`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Both of those jobs run on `ubuntu-latest`, `windows-latest` and `macos-latest`, so a fix that only holds on POSIX paths or POSIX line endings fails the matrix. The ubuntu/Python 3.12 coverage cell alone installs against `constraints.txt`, regenerated at each release; the remaining matrix cells, core installs and audit resolution deliberately float. Separate jobs gate the three ruff stack invariants, `interrogate` docstring coverage at 100%, and `pip-audit` over the dependency tree resolved from `pyproject.toml`. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
 
-Line coverage measured **99.09%** on the 1272-test dev suite. The
+Line coverage measured **99.03%** on the 1276-test dev suite. The
 ubuntu/3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 99`; this floor rises
 whenever measured coverage rises, and lowering it requires a dated `CHANGELOG.md` note.
 The measured scope is not the whole package: `[tool.coverage.run] omit` drops `reports/` alongside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+**Coverage floor raised (2026-08-13):** `fail_under` rises from `95` to `99`; measured coverage
+over the scope narrowed in 6.17.0 is 99.09%, on a suite grown from 1145 to 1272 tests. The
+floor rises whenever measured coverage rises, and lowering it requires a dated note here.
+
+### Added
+
+- Tests for the three signal-backtest factsheet builders in `alphas/backtest_alphas.py`,
+  including a sweep assertion on the recorded target weights rather than on the leg labels,
+  which are derived from the sweep values and would look correct even if the span never
+  reached `compute_signal_scores`.
+- Validation coverage across all three `minimum_tracking_error` entry points, and both
+  `max_sharpe` solver paths with an assertion on which solver actually ran — the
+  Charnes-Cooper transform and the SciPy SLSQP fallback return the same outcome type, so a
+  mis-routed problem is otherwise indistinguishable from a solved one.
+- Tests for `residual_reversal`'s four dispatch branches, pinning the raw signal as the exact
+  negation of `compute_residual_momentum_alpha`. A dropped negation leaves a signal that still
+  scores and still backtests, while buying momentum winners under a module named reversal.
+- Tests for the target-yield solver's soft-tracking-error branch, the risk-budgeting solver's
+  input validation and box-infeasibility guards, and the mixed-cadence-with-groups path shared
+  by `carry`, `low_beta`, `momentum` and `residual_momentum` — the one path that partitions the
+  universe twice and merges the cells back, where a dropped or duplicated ticker still yields a
+  full-looking score panel.
+
 ### Fixed
 
 - Made soft tracking error ignore a populated hard tracking-error budget during both the solve
@@ -20,8 +43,8 @@ alongside `tests/`, `examples/` and `papers/`. The reporting layer renders facts
 `qis` and `pybloqs` and is reviewed by eye rather than by assertion; measured at 3.9% it
 contributed 223 of the 597 missed lines and did nothing but dilute the ratchet. Anything with
 a numerical contract belongs outside `reports/`, where it is still measured. The floor rises
-from `fail_under = 88` to `98`: measured coverage over the narrowed scope is 98.31%, up from
-92.99% at the moment of the scope change, on a suite grown from 1077 to 1200 tests.
+from `fail_under = 88` to `95`: measured coverage over the narrowed scope is 96.18%, up from
+92.99% at the moment of the scope change, on a suite grown from 1077 to 1145 tests.
 
 ### Added
 
@@ -34,17 +57,6 @@ from `fail_under = 88` to `98`: measured coverage over the narrowed scope is 98.
   (`alphas/alpha_data.py`), the HCGL covariance report (`covar_estimation/covar_reporting.py`),
   the CVXPY covariance stabiliser (`optimization/covar_factorization.py`), and the
   settings-path accessors (`local_path.py`).
-- Tests for the three signal-backtest factsheet builders in `alphas/backtest_alphas.py`,
-  including a sweep assertion on the recorded target weights rather than on the leg labels,
-  which are derived from the sweep values and would look correct even if the span never
-  reached `compute_signal_scores`.
-- Validation coverage across all three `minimum_tracking_error` entry points, and both
-  `max_sharpe` solver paths with an assertion on which solver actually ran — the
-  Charnes-Cooper transform and the SciPy SLSQP fallback return the same outcome type, so a
-  mis-routed problem is otherwise indistinguishable from a solved one.
-- Tests for `residual_reversal`'s four dispatch branches, pinning the raw signal as the exact
-  negation of `compute_residual_momentum_alpha`. A dropped negation leaves a signal that still
-  scores and still backtests, while buying momentum winners under a module named reversal.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ alongside `tests/`, `examples/` and `papers/`. The reporting layer renders facts
 `qis` and `pybloqs` and is reviewed by eye rather than by assertion; measured at 3.9% it
 contributed 223 of the 597 missed lines and did nothing but dilute the ratchet. Anything with
 a numerical contract belongs outside `reports/`, where it is still measured. The floor rises
-from `fail_under = 88` to `95`: measured coverage over the narrowed scope is 96.18%, up from
-92.99% at the moment of the scope change, on a suite grown from 1077 to 1145 tests.
+from `fail_under = 88` to `98`: measured coverage over the narrowed scope is 98.31%, up from
+92.99% at the moment of the scope change, on a suite grown from 1077 to 1200 tests.
 
 ### Added
 
@@ -34,6 +34,17 @@ from `fail_under = 88` to `95`: measured coverage over the narrowed scope is 96.
   (`alphas/alpha_data.py`), the HCGL covariance report (`covar_estimation/covar_reporting.py`),
   the CVXPY covariance stabiliser (`optimization/covar_factorization.py`), and the
   settings-path accessors (`local_path.py`).
+- Tests for the three signal-backtest factsheet builders in `alphas/backtest_alphas.py`,
+  including a sweep assertion on the recorded target weights rather than on the leg labels,
+  which are derived from the sweep values and would look correct even if the span never
+  reached `compute_signal_scores`.
+- Validation coverage across all three `minimum_tracking_error` entry points, and both
+  `max_sharpe` solver paths with an assertion on which solver actually ran — the
+  Charnes-Cooper transform and the SciPy SLSQP fallback return the same outcome type, so a
+  mis-routed problem is otherwise indistinguishable from a solved one.
+- Tests for `residual_reversal`'s four dispatch branches, pinning the raw signal as the exact
+  negation of `compute_residual_momentum_alpha`. A dropped negation leaves a signal that still
+  scores and still backtests, while buying momentum winners under a module named reversal.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 **Coverage floor raised (2026-08-13):** `fail_under` rises from `95` to `99`; measured coverage
-over the scope narrowed in 6.17.0 is 99.09%, on a suite grown from 1145 to 1272 tests. The
+over the scope narrowed in 6.17.0 is 99.03%, on a suite grown from 1145 to 1276 tests. The
 floor rises whenever measured coverage rises, and lowering it requires a dated note here.
 
 ### Added

--- a/optimalportfolios/alphas/signals/tests/mixed_cadence_grouping_test.py
+++ b/optimalportfolios/alphas/signals/tests/mixed_cadence_grouping_test.py
@@ -1,0 +1,186 @@
+"""
+the mixed-cadence-with-groups branch, across all four signal modules.
+
+Every signal here dispatches on the *type* of ``returns_freq``: a string means one cadence for
+the whole universe, a Series means per-asset cadences computed separately and merged. Crossed
+with that, ``group_data`` switches scoring from the full cross-section to within-group. The
+combination -- a Series cadence *and* group labels -- is the one path where the universe is
+partitioned twice, once by cadence and once by group, and each cell is scored on its own.
+
+That double split is where an alignment bug hides. Each cell is scored independently and the
+results are concatenated, so a cell that silently drops or duplicates a ticker still produces a
+full-looking panel; the merge just fills the gap from another cell or keeps the first copy. The
+tests below therefore assert on the *column set* of the merged result and on the group labels
+actually used, rather than only on the panel's shape.
+
+Written as one parametrised suite because the four modules implement the identical branch with
+different inner signal functions -- and because a fifth signal added later should be able to
+join the list rather than acquire its own copy of these cases.
+"""
+# packages
+import pandas as pd
+import pytest
+import qis
+# optimalportfolios
+from optimalportfolios.alphas.signals.carry import (
+    compute_ra_carry_alpha,
+    compute_ra_carry_alphas,
+)
+from optimalportfolios.alphas.signals.low_beta import compute_low_beta_alpha
+from optimalportfolios.alphas.signals.momentum import compute_momentum_alpha
+from optimalportfolios.alphas.signals.residual_momentum import compute_residual_momentum_alpha
+from optimalportfolios.tests.data.multiasset import load_multiasset_data
+
+
+@pytest.fixture(scope='module')
+def universe() -> dict:
+    """A decade of the committed monthly universe, its groups, and a carry panel."""
+    data = load_multiasset_data()
+    prices = data.prices.loc['2010':'2019', :]
+    carry = pd.DataFrame(0.02, index=prices.index, columns=prices.columns)
+    carry.iloc[:, :5] = 0.06                    # a stable cross-sectional carry spread
+    return dict(prices=prices,
+                benchmark_price=prices.iloc[:, 0],
+                group_data=data.group_data,
+                carry=carry)
+
+
+def split_cadences(columns: pd.Index) -> pd.Series:
+    """Assign half the universe to quarterly and half to monthly cadence."""
+    freqs = pd.Series('ME', index=columns)
+    freqs.iloc[: len(freqs) // 2] = 'QE'
+    return freqs
+
+
+SPANS = {'ME': 12, 'QE': 4}
+SHORT_SPANS = {'ME': 13, 'QE': 4}
+
+
+def call_signal(name: str, universe: dict, returns_freq, group_data) -> tuple:
+    """Invoke one signal by name with cadence-appropriate spans."""
+    common = dict(prices=universe['prices'], returns_freq=returns_freq, group_data=group_data)
+    if name == 'carry':
+        return compute_ra_carry_alpha(carry=universe['carry'], vol_span=SHORT_SPANS, **common)
+    if name == 'low_beta':
+        return compute_low_beta_alpha(benchmark_price=universe['benchmark_price'],
+                                      beta_span=SPANS, **common)
+    if name == 'momentum':
+        return compute_momentum_alpha(benchmark_price=universe['benchmark_price'],
+                                      long_span=SPANS, vol_span=SHORT_SPANS, **common)
+    if name == 'residual_momentum':
+        return compute_residual_momentum_alpha(benchmark_price=universe['benchmark_price'],
+                                               beta_span=SPANS, long_span=SPANS,
+                                               vol_span=SHORT_SPANS, **common)
+    raise AssertionError(f"unknown signal {name!r}")
+
+
+SIGNALS = ['carry', 'low_beta', 'momentum', 'residual_momentum']
+
+
+# --------------------------------------------------------------------------- #
+# the mixed-cadence path, grouped and ungrouped
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize('signal', SIGNALS)
+def test_mixed_cadences_with_groups_cover_the_whole_universe(signal: str,
+                                                             universe: dict) -> None:
+    """The double split by cadence and group must merge back to every ticker, exactly once."""
+    prices = universe['prices']
+    scores, raw = call_signal(signal, universe,
+                              returns_freq=split_cadences(prices.columns),
+                              group_data=universe['group_data'])
+    assert set(scores.columns) == set(prices.columns)
+    assert set(raw.columns) == set(prices.columns)
+    assert not scores.columns.has_duplicates
+    assert not raw.columns.has_duplicates
+
+
+@pytest.mark.parametrize('signal', SIGNALS)
+def test_mixed_cadences_without_groups_cover_the_whole_universe(signal: str,
+                                                               universe: dict) -> None:
+    """The cadence split alone must also merge back to the full column set."""
+    prices = universe['prices']
+    scores, _ = call_signal(signal, universe,
+                            returns_freq=split_cadences(prices.columns),
+                            group_data=None)
+    assert set(scores.columns) == set(prices.columns)
+
+
+@pytest.mark.parametrize('signal', SIGNALS)
+def test_grouping_changes_the_score_under_mixed_cadences(signal: str,
+                                                         universe: dict) -> None:
+    """Within-group scoring is not a no-op: the same raw signal scores differently.
+
+    If ``group_data`` were dropped on the way into the cadence loop, these would be identical
+    while every shape assertion above still passed.
+    """
+    prices = universe['prices']
+    freqs = split_cadences(prices.columns)
+    grouped, _ = call_signal(signal, universe, returns_freq=freqs,
+                             group_data=universe['group_data'])
+    ungrouped, _ = call_signal(signal, universe, returns_freq=freqs, group_data=None)
+    common = grouped.columns.intersection(ungrouped.columns)
+    assert not grouped[common].equals(ungrouped[common])
+
+
+@pytest.mark.parametrize('signal', SIGNALS)
+def test_the_raw_signal_differs_between_cadences(signal: str, universe: dict) -> None:
+    """A quarterly asset must not be computed on the monthly cadence.
+
+    Comparing the same asset under an all-monthly panel against a mixed panel that assigns it
+    to quarterly is what shows the per-asset cadence actually reached the inner computation.
+    """
+    prices = universe['prices']
+    freqs = split_cadences(prices.columns)
+    # not column 0: that is the benchmark itself, whose excess return over itself is zero, so
+    # the vol-normalised signal is NaN on every date and every cadence compares equal
+    quarterly_ticker = freqs.index[1]
+    assert freqs[quarterly_ticker] == 'QE'
+
+    _, mixed_raw = call_signal(signal, universe, returns_freq=freqs, group_data=None)
+    _, monthly_raw = call_signal(signal, universe, returns_freq='ME', group_data=None)
+    mixed_col = mixed_raw[quarterly_ticker].dropna()
+    monthly_col = monthly_raw[quarterly_ticker].dropna()
+    assert not mixed_col.empty                           # a vacuous comparison proves nothing
+    assert not mixed_col.equals(monthly_col)
+
+
+@pytest.mark.parametrize('signal', SIGNALS)
+def test_a_single_cadence_series_still_takes_the_mixed_path(signal: str,
+                                                            universe: dict) -> None:
+    """A Series naming one cadence for every asset routes through the merge, not the fast path.
+
+    It should agree with the equivalent scalar call: the merge over a single cell must be the
+    identity, which is the cheapest available check that the concatenation preserves order.
+    """
+    prices = universe['prices']
+    uniform = pd.Series('ME', index=prices.columns)
+    via_series, _ = call_signal(signal, universe, returns_freq=uniform, group_data=None)
+    via_scalar, _ = call_signal(signal, universe, returns_freq='ME', group_data=None)
+    assert set(via_series.columns) == set(via_scalar.columns)
+    pd.testing.assert_frame_equal(via_series[via_scalar.columns], via_scalar)
+
+
+# --------------------------------------------------------------------------- #
+# the legacy carry entry point
+# --------------------------------------------------------------------------- #
+def test_the_legacy_carry_entry_point_returns_only_the_score(universe: dict) -> None:
+    """``compute_ra_carry_alphas`` is retained for callers of the original signature.
+
+    It returns the score alone rather than the (score, raw) tuple, and forces ungrouped
+    scoring regardless of any group structure in the universe.
+    """
+    score = compute_ra_carry_alphas(prices=universe['prices'], carry=universe['carry'],
+                                    returns_freq='ME', vol_span=13)
+    assert isinstance(score, pd.DataFrame)
+    expected, _ = compute_ra_carry_alpha(prices=universe['prices'], carry=universe['carry'],
+                                         returns_freq='ME', group_data=None, vol_span=13)
+    pd.testing.assert_frame_equal(score, expected)
+
+
+def test_the_legacy_carry_entry_point_accepts_a_mean_adjustment(universe: dict) -> None:
+    """``mean_adj_type`` is threaded through to the vol normalisation, not defaulted away."""
+    common = dict(prices=universe['prices'], carry=universe['carry'], returns_freq='ME',
+                  vol_span=13)
+    ewma = compute_ra_carry_alphas(mean_adj_type=qis.MeanAdjType.EWMA, **common)
+    none_adj = compute_ra_carry_alphas(mean_adj_type=qis.MeanAdjType.NONE, **common)
+    assert not ewma.equals(none_adj)

--- a/optimalportfolios/alphas/signals/tests/residual_reversal_test.py
+++ b/optimalportfolios/alphas/signals/tests/residual_reversal_test.py
@@ -1,0 +1,199 @@
+"""
+residual reversal, and the four dispatch branches its entry point hides.
+
+The signal itself is residual momentum with a sign flip: strip the benchmark beta, EWMA-filter
+the residual, negate. The tests that matter here are not about the filter -- they are about
+which of four code paths a given set of arguments lands on, because all four return the same
+two frames and none of them announces itself.
+
+``compute_residual_reversal_alpha`` dispatches on the *type* of ``returns_freq``: a string
+means one cadence for the whole universe, a Series means per-asset cadences and a merge across
+(frequency x group). Orthogonally, ``group_data`` switches scoring from the full cross-section
+to within-group. A caller who passes a scalar where a Series was intended gets a complete,
+plausible score panel computed on the wrong cadence for most of the universe.
+
+The sign is asserted directly against ``compute_residual_momentum_alpha``: the raw signals must
+be exact negations of each other. That is the one property distinguishing this module from its
+neighbour, and it is stated in the docstring, so it is worth a test rather than trust -- a
+dropped negation leaves a signal that still scores, still backtests, and buys the momentum
+winners while the module name says reversal.
+"""
+# packages
+import numpy as np
+import pandas as pd
+import pytest
+import qis
+# optimalportfolios
+from optimalportfolios.alphas.signals.residual_momentum import compute_residual_momentum_alpha
+from optimalportfolios.alphas.signals.residual_reversal import (
+    compute_residual_reversal_alpha,
+    compute_residual_reversal_cluster_alpha,
+)
+from optimalportfolios.tests.data.multiasset import load_multiasset_data
+
+
+@pytest.fixture(scope='module')
+def universe() -> dict:
+    """A decade of the committed monthly universe with its group labels."""
+    data = load_multiasset_data()
+    prices = data.prices.loc['2010':'2019', :]
+    return dict(prices=prices,
+                benchmark_price=prices.iloc[:, 0],
+                group_data=data.group_data)
+
+
+# --------------------------------------------------------------------------- #
+# the benchmark default
+# --------------------------------------------------------------------------- #
+def test_no_benchmark_falls_back_to_the_equal_weight_cross_section(universe: dict) -> None:
+    """With no benchmark the cross-sectional mean return stands in for one.
+
+    Worth pinning because it is silent: omitting the benchmark does not raise, it changes what
+    'residual' means for every asset in the panel.
+    """
+    prices = universe['prices']
+    without, raw_without = compute_residual_reversal_alpha(prices=prices)
+    with_bench, _ = compute_residual_reversal_alpha(prices=prices,
+                                                    benchmark_price=universe['benchmark_price'])
+    assert raw_without.shape == (len(prices), len(prices.columns))
+    assert not without.equals(with_bench)          # a different residual, not a no-op
+
+
+# --------------------------------------------------------------------------- #
+# the sign flip
+# --------------------------------------------------------------------------- #
+def test_the_raw_signal_is_the_exact_negation_of_residual_momentum(universe: dict) -> None:
+    """Reversal and momentum share one raw computation and differ only by sign."""
+    kwargs = dict(prices=universe['prices'], benchmark_price=universe['benchmark_price'],
+                  returns_freq='ME', beta_span=12, long_span=1, vol_span=13)
+    _, raw_reversal = compute_residual_reversal_alpha(**kwargs)
+    _, raw_momentum = compute_residual_momentum_alpha(**kwargs)
+    pd.testing.assert_frame_equal(raw_reversal, -raw_momentum)
+
+
+def test_a_recent_residual_loser_scores_above_a_winner(universe: dict) -> None:
+    """The negation is what makes a loser attractive; the score ordering must reflect it."""
+    _, raw = compute_residual_reversal_alpha(prices=universe['prices'],
+                                             benchmark_price=universe['benchmark_price'])
+    scores, _ = compute_residual_reversal_alpha(prices=universe['prices'],
+                                                benchmark_price=universe['benchmark_price'])
+    date = scores.dropna(how='all').index[-1]
+    row_raw, row_score = raw.loc[date, :].dropna(), scores.loc[date, :].dropna()
+    common = row_raw.index.intersection(row_score.index)
+    # scoring is monotone in the raw signal, so their rank orders agree
+    assert (row_raw[common].rank().equals(row_score[common].rank()))
+
+
+# --------------------------------------------------------------------------- #
+# the four dispatch branches
+# --------------------------------------------------------------------------- #
+def test_a_string_frequency_takes_the_single_cadence_path(universe: dict) -> None:
+    """One cadence for the whole universe: the panel keeps every column."""
+    scores, raw = compute_residual_reversal_alpha(prices=universe['prices'],
+                                                  benchmark_price=universe['benchmark_price'],
+                                                  returns_freq='ME')
+    assert list(scores.columns) == list(universe['prices'].columns)
+    assert list(raw.columns) == list(universe['prices'].columns)
+
+
+def test_the_single_cadence_path_scores_within_groups_when_asked(universe: dict) -> None:
+    """With ``group_data`` the score is a within-group z-score, not a panel-wide one."""
+    prices, group_data = universe['prices'], universe['group_data']
+    grouped, _ = compute_residual_reversal_alpha(prices=prices,
+                                                 benchmark_price=universe['benchmark_price'],
+                                                 returns_freq='ME', group_data=group_data)
+    ungrouped, _ = compute_residual_reversal_alpha(prices=prices,
+                                                   benchmark_price=universe['benchmark_price'],
+                                                   returns_freq='ME')
+    assert list(grouped.columns) == list(prices.columns)     # original column order restored
+    assert not grouped.equals(ungrouped)
+
+
+def test_a_frequency_series_takes_the_mixed_cadence_path(universe: dict) -> None:
+    """Per-asset cadences are computed separately and merged back onto the full universe."""
+    prices = universe['prices']
+    freqs = pd.Series('ME', index=prices.columns)
+    freqs.iloc[: len(freqs) // 2] = 'QE'
+    scores, raw = compute_residual_reversal_alpha(prices=prices,
+                                                  benchmark_price=universe['benchmark_price'],
+                                                  returns_freq=freqs,
+                                                  beta_span={'ME': 12, 'QE': 4},
+                                                  long_span={'ME': 1, 'QE': 1},
+                                                  vol_span={'ME': 13, 'QE': 4})
+    assert set(scores.columns) == set(prices.columns)
+    assert set(raw.columns) == set(prices.columns)
+
+
+def test_the_mixed_cadence_path_also_scores_within_groups(universe: dict) -> None:
+    """Cadence and group partition the universe independently; both splits apply."""
+    prices, group_data = universe['prices'], universe['group_data']
+    freqs = pd.Series('ME', index=prices.columns)
+    freqs.iloc[: len(freqs) // 2] = 'QE'
+    scores, _ = compute_residual_reversal_alpha(prices=prices,
+                                                benchmark_price=universe['benchmark_price'],
+                                                returns_freq=freqs,
+                                                group_data=group_data,
+                                                beta_span={'ME': 12, 'QE': 4},
+                                                long_span={'ME': 1, 'QE': 1},
+                                                vol_span={'ME': 13, 'QE': 4})
+    assert set(scores.columns) == set(prices.columns)
+
+
+# --------------------------------------------------------------------------- #
+# cluster scoring
+# --------------------------------------------------------------------------- #
+def test_cluster_scoring_returns_the_shared_raw_signal(universe: dict) -> None:
+    """The cluster entry point changes only the scoring, so the raw signal is unchanged."""
+    prices = universe['prices']
+    dates = prices.index[-6:]
+    clusters = {date: pd.Series(np.arange(len(prices.columns)) % 3, index=prices.columns)
+                for date in dates}
+    _, raw_cluster = compute_residual_reversal_cluster_alpha(
+        prices=prices, benchmark_price=universe['benchmark_price'],
+        rolling_clusters=clusters, returns_freq='ME')
+    _, raw_plain = compute_residual_reversal_alpha(
+        prices=prices, benchmark_price=universe['benchmark_price'], returns_freq='ME')
+    pd.testing.assert_frame_equal(raw_cluster, raw_plain)
+
+
+def test_cluster_scoring_still_negates_relative_to_residual_momentum(universe: dict) -> None:
+    """The sign flip lives in the shared raw signal, so it survives cluster scoring."""
+    prices = universe['prices']
+    clusters = {date: pd.Series(np.arange(len(prices.columns)) % 3, index=prices.columns)
+                for date in prices.index[-6:]}
+    _, raw_cluster = compute_residual_reversal_cluster_alpha(
+        prices=prices, benchmark_price=universe['benchmark_price'],
+        rolling_clusters=clusters, returns_freq='ME')
+    _, raw_momentum = compute_residual_momentum_alpha(
+        prices=prices, benchmark_price=universe['benchmark_price'], returns_freq='ME',
+        beta_span=12, long_span=1, vol_span=13)
+    pd.testing.assert_frame_equal(raw_cluster, -raw_momentum)
+
+
+def test_the_returned_frames_share_the_price_index(universe: dict) -> None:
+    """Scores and raw signal are reported on the price index, whatever the cadence."""
+    prices = universe['prices']
+    scores, raw = compute_residual_reversal_alpha(prices=prices,
+                                                  benchmark_price=universe['benchmark_price'],
+                                                  returns_freq='ME')
+    assert isinstance(scores.index, pd.DatetimeIndex)
+    assert scores.index.equals(raw.index)
+    assert scores.index[-1] <= prices.index[-1]
+
+
+def test_disabling_vol_normalisation_changes_the_signal(universe: dict) -> None:
+    """``vol_span=None`` turns off the risk adjustment rather than defaulting it back on."""
+    common = dict(prices=universe['prices'], benchmark_price=universe['benchmark_price'],
+                  returns_freq='ME')
+    _, normalised = compute_residual_reversal_alpha(vol_span=13, **common)
+    _, unnormalised = compute_residual_reversal_alpha(vol_span=None, **common)
+    assert not normalised.equals(unnormalised)
+
+
+def test_an_explicit_mean_adjustment_reaches_the_beta_regression(universe: dict) -> None:
+    """``mean_adj_type`` is threaded to the EWMA beta estimate, not silently defaulted."""
+    common = dict(prices=universe['prices'], benchmark_price=universe['benchmark_price'],
+                  returns_freq='ME')
+    _, ewma = compute_residual_reversal_alpha(mean_adj_type=qis.MeanAdjType.EWMA, **common)
+    _, none_adj = compute_residual_reversal_alpha(mean_adj_type=qis.MeanAdjType.NONE, **common)
+    assert not ewma.equals(none_adj)

--- a/optimalportfolios/alphas/signals/tests/residual_reversal_test.py
+++ b/optimalportfolios/alphas/signals/tests/residual_reversal_test.py
@@ -72,16 +72,40 @@ def test_the_raw_signal_is_the_exact_negation_of_residual_momentum(universe: dic
 
 
 def test_a_recent_residual_loser_scores_above_a_winner(universe: dict) -> None:
-    """The negation is what makes a loser attractive; the score ordering must reflect it."""
-    _, raw = compute_residual_reversal_alpha(prices=universe['prices'],
-                                             benchmark_price=universe['benchmark_price'])
-    scores, _ = compute_residual_reversal_alpha(prices=universe['prices'],
-                                                benchmark_price=universe['benchmark_price'])
+    """The worst residual momentum must come out with the highest reversal score.
+
+    Stated against ``compute_residual_momentum_alpha`` rather than against the module's own raw
+    frame, because the two together are what the claim needs: scoring is monotone in the raw
+    signal, so a rank comparison within this module holds whether or not the negation happened
+    and proves only that the scorer is order-preserving. Anchoring the extremes on the momentum
+    panel is what fails if the sign is dropped.
+
+    The spans are passed explicitly because the two entry points do not share their defaults:
+    reversal filters at ``long_span=1`` and momentum at ``12``, which is the horizon difference
+    that makes one a reversal signal at all. Left implicit, the panels would be two different
+    signals and the comparison would say nothing about the sign.
+    """
+    kwargs = dict(prices=universe['prices'], benchmark_price=universe['benchmark_price'],
+                  beta_span=12, long_span=1, vol_span=13)
+    scores, raw_reversal = compute_residual_reversal_alpha(**kwargs)
+    _, raw_momentum = compute_residual_momentum_alpha(**kwargs)
+
     date = scores.dropna(how='all').index[-1]
-    row_raw, row_score = raw.loc[date, :].dropna(), scores.loc[date, :].dropna()
-    common = row_raw.index.intersection(row_score.index)
-    # scoring is monotone in the raw signal, so their rank orders agree
-    assert (row_raw[common].rank().equals(row_score[common].rank()))
+    row_score = scores.loc[date, :].dropna()
+    row_momentum = raw_momentum.loc[date, :].dropna()
+    common = row_score.index.intersection(row_momentum.index)
+    assert len(common) >= 2
+
+    worst_momentum = row_momentum[common].idxmin()
+    best_momentum = row_momentum[common].idxmax()
+    assert row_score[worst_momentum] == row_score[common].max()
+    assert row_score[best_momentum] == row_score[common].min()
+    assert row_score[worst_momentum] > row_score[best_momentum]
+
+    # and the scorer is order-preserving, which is why the extremes above transfer
+    row_raw = raw_reversal.loc[date, :].dropna()
+    shared = row_raw.index.intersection(row_score.index)
+    assert row_raw[shared].rank().equals(row_score[shared].rank())
 
 
 # --------------------------------------------------------------------------- #

--- a/optimalportfolios/alphas/tests/backtest_alphas_test.py
+++ b/optimalportfolios/alphas/tests/backtest_alphas_test.py
@@ -1,0 +1,181 @@
+"""
+the three signal-backtest factsheet builders.
+
+``compute_signal_scores`` is covered next door in ``cluster_scoring_test.py``; what is left
+here is the layer that turns a score panel into portfolios and a factsheet. These are report
+generators, so the assertions are about the wiring rather than about the pictures: which legs
+get built, in what order, and whether the caller's parameters actually reach the signal
+computation underneath.
+
+That last point is the one worth spending assertions on. Each of these functions takes six or
+more span parameters and threads them through ``compute_signal_scores`` by keyword; a
+parameter dropped on the way through produces a perfectly good factsheet of the wrong
+backtest, and nothing downstream notices. ``cross_backtest_alpha_signals`` is the sharpest
+case -- its whole purpose is to vary one span while holding the others fixed, so the legs it
+builds are checked against the sweep values by name.
+
+The equal-weight leg is asserted to come *first* in the multi and cross backtests and *second*
+in the single-signal one, because those orderings are not the same and both are load-bearing
+for how the factsheet labels its benchmark.
+"""
+# packages
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import qis
+# optimalportfolios
+from optimalportfolios.alphas.backtest_alphas import (
+    AlphaSignal,
+    CrossBacktestParam,
+    backtest_alpha_signals,
+    cross_backtest_alpha_signals,
+    multi_backtest_alpha_signals,
+)
+from optimalportfolios.tests.data.multiasset import load_multiasset_data
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    """Factsheets open many figures; drop them so the Agg registry does not grow."""
+    yield
+    plt.close('all')
+
+
+@pytest.fixture(scope='module')
+def universe() -> dict:
+    """A short window of the committed monthly universe plus the report inputs."""
+    data = load_multiasset_data()
+    prices = data.prices.loc['2014':'2019', :]
+    group_data = data.group_data
+    return dict(prices=prices,
+                group_data=group_data,
+                group_order=list(pd.unique(group_data)),
+                rebalancing_costs=pd.Series(0.0010, index=prices.columns),
+                benchmark_prices=prices.iloc[:, :1],
+                time_period=qis.TimePeriod('2015-01-01', '2019-12-31'))
+
+
+# --------------------------------------------------------------------------- #
+# backtest_alpha_signals
+# --------------------------------------------------------------------------- #
+def test_a_single_signal_backtest_renders_a_factsheet(universe: dict) -> None:
+    """The strategy-vs-benchmark factsheet builds for the default momentum signal."""
+    figs = backtest_alpha_signals(alpha_signal=AlphaSignal.MOMENTUM, **universe)
+    assert len(figs) > 0
+    assert all(isinstance(fig, plt.Figure) for fig in figs)
+
+
+@pytest.mark.parametrize('alpha_signal', list(AlphaSignal))
+def test_every_signal_can_be_backtested(universe: dict, alpha_signal: AlphaSignal) -> None:
+    """All five signals reach the backtester, composites included.
+
+    The two composite signals forward their smoothing span to ``compute_residual_momentum_alpha``
+    as ``long_span``; passing it as ``momentum_span`` used to raise TypeError, so these signals
+    never ran at all. Parametrising over the whole enum is what keeps that from recurring.
+    """
+    figs = backtest_alpha_signals(alpha_signal=alpha_signal, **universe)
+    assert len(figs) > 0
+
+
+def test_the_single_signal_backtest_names_its_legs_signal_then_benchmark(universe: dict,
+                                                                         monkeypatch) -> None:
+    """The signal leg is built first and the equal-weight benchmark second."""
+    tickers = []
+    original = qis.backtest_model_portfolio
+
+    def recording(**kwargs):
+        """Record each leg's ticker and delegate to the real backtester."""
+        tickers.append(kwargs['ticker'])
+        return original(**kwargs)
+
+    monkeypatch.setattr(qis, 'backtest_model_portfolio', recording)
+    backtest_alpha_signals(alpha_signal=AlphaSignal.LOW_BETA, **universe)
+    assert tickers == ['LowBeta', 'Equal Weight']
+
+
+# --------------------------------------------------------------------------- #
+# multi_backtest_alpha_signals
+# --------------------------------------------------------------------------- #
+def test_the_multi_backtest_builds_one_leg_per_signal_plus_equal_weight(universe: dict,
+                                                                        monkeypatch) -> None:
+    """Every AlphaSignal becomes a leg, with equal weight built first."""
+    tickers = []
+    original = qis.backtest_model_portfolio
+
+    def recording(**kwargs):
+        """Record each leg's ticker and delegate to the real backtester."""
+        tickers.append(kwargs['ticker'])
+        return original(**kwargs)
+
+    monkeypatch.setattr(qis, 'backtest_model_portfolio', recording)
+    figs = multi_backtest_alpha_signals(**universe)
+    assert tickers == ['Equal Weight'] + [signal.value for signal in AlphaSignal]
+    assert len(figs) > 0
+
+
+# --------------------------------------------------------------------------- #
+# cross_backtest_alpha_signals
+# --------------------------------------------------------------------------- #
+SPAN_VALUES = [3, 6, 12, 18, 24, 36, 60]
+
+
+def record_legs(monkeypatch) -> list:
+    """Patch the backtester to record leg tickers, and return the list it fills."""
+    tickers = []
+    original = qis.backtest_model_portfolio
+
+    def recording(**kwargs):
+        """Record each leg's ticker and delegate to the real backtester."""
+        tickers.append(kwargs['ticker'])
+        return original(**kwargs)
+
+    monkeypatch.setattr(qis, 'backtest_model_portfolio', recording)
+    return tickers
+
+
+@pytest.mark.parametrize('param, label', [
+    (CrossBacktestParam.MOM_SPAN, 'long_span'),
+    (CrossBacktestParam.BETA_SPAN, 'beta_span'),
+    (CrossBacktestParam.MOM_BETA_SPAN, 'spans'),
+    (CrossBacktestParam.RESIDUAL_MOM_SPAN, 'res_mom_span'),
+])
+def test_each_sweep_labels_its_legs_with_the_swept_values(universe: dict, monkeypatch,
+                                                          param: CrossBacktestParam,
+                                                          label: str) -> None:
+    """The sweep builds one leg per span value, named for the parameter it varies.
+
+    This is the assertion that catches a sweep wired to the wrong keyword: the legs would
+    still be built and still be labelled, but every one of them would hold the same portfolio.
+    """
+    tickers = record_legs(monkeypatch)
+    figs = cross_backtest_alpha_signals(cross_backtest_param=param, **universe)
+    assert tickers == ['Equal Weight'] + [f"{label}={span:0.0f}" for span in SPAN_VALUES]
+    assert len(figs) > 0
+
+
+def test_a_sweep_actually_varies_the_portfolios(universe: dict, monkeypatch) -> None:
+    """The swept legs must hold *different* portfolios, not just carry different labels.
+
+    Labels are built from the sweep values directly, so they would look right even if the span
+    never reached ``compute_signal_scores``. The weights are what actually prove it did.
+    """
+    weights = {}
+    original = qis.backtest_model_portfolio
+
+    def recording(**kwargs):
+        """Record each leg's target weights and delegate to the real backtester."""
+        weights[kwargs['ticker']] = kwargs['weights']
+        return original(**kwargs)
+
+    monkeypatch.setattr(qis, 'backtest_model_portfolio', recording)
+    cross_backtest_alpha_signals(cross_backtest_param=CrossBacktestParam.MOM_SPAN, **universe)
+
+    swept = [weights[f"long_span={span:0.0f}"] for span in SPAN_VALUES]
+    for faster, slower in zip(swept, swept[1:]):
+        assert not faster.equals(slower)
+
+
+def test_an_unknown_sweep_parameter_raises(universe: dict) -> None:
+    """The sweep dispatch is exhaustive over the enum and refuses anything else."""
+    with pytest.raises(NotImplementedError):
+        cross_backtest_alpha_signals(cross_backtest_param='MOM_SPAN', **universe)

--- a/optimalportfolios/optimization/tests/max_sharpe_paths_test.py
+++ b/optimalportfolios/optimization/tests/max_sharpe_paths_test.py
@@ -1,0 +1,170 @@
+"""
+the two solver paths behind maximum Sharpe, and how the dispatcher chooses between them.
+
+Maximising Sharpe is not a convex problem as written. ``cvx_maximize_portfolio_sharpe``
+handles that by dispatching on the exposure constraints: when ``min_exposure ==
+max_exposure`` the problem admits the Charnes-Cooper transform, which turns the ratio into a
+genuine convex program in a scaled variable; when they differ there is no equality sum
+constraint to normalise against, so it falls back to SciPy SLSQP on the raw ratio.
+
+That dispatch is the thing worth pinning. Both branches return the same outcome type and both
+produce plausible weights, so a mis-routed problem looks exactly like a solved one -- it is
+simply solved by a local method with no convexity guarantee when a global one was available,
+or handed to a transform whose derivation assumed a constraint that is not there. The tests
+below assert which solver actually ran, via the solver recorded on the outcome, rather than
+inferring it from the weights.
+
+The Charnes-Cooper path also unscales its solution by dividing through the auxiliary variable
+``k``; the recovered weights are checked against the exposure they are supposed to hit, since
+a scaling error there produces weights that are wrong by a constant factor and otherwise
+entirely reasonable-looking. The ``SolverError`` fallback is covered for the same reason it is
+in the TRE solver: it must degrade to a rejected outcome, not kill a rolling backtest.
+"""
+# packages
+import cvxpy as cvx
+import numpy as np
+import pandas as pd
+import pytest
+# optimalportfolios
+from optimalportfolios.optimization.constraints import Constraints
+from optimalportfolios.optimization.general.max_sharpe import (
+    cvx_maximize_portfolio_sharpe,
+    wrapper_maximize_portfolio_sharpe,
+)
+
+TICKERS = pd.Index(['A', 'B', 'C', 'D'])
+
+
+def covar_matrix() -> np.ndarray:
+    """A well-conditioned 4-asset covariance."""
+    vols = np.array([0.20, 0.12, 0.08, 0.05])
+    corr = np.array([
+        [1.00, 0.30, 0.10, 0.00],
+        [0.30, 1.00, 0.20, 0.10],
+        [0.10, 0.20, 1.00, 0.25],
+        [0.00, 0.10, 0.25, 1.00],
+    ])
+    return np.outer(vols, vols) * corr
+
+
+def means_vector() -> np.ndarray:
+    """Expected returns with a clear cross-sectional spread."""
+    return np.array([0.08, 0.05, 0.03, 0.02])
+
+
+def make_constraints(min_exposure: float = 1.0, max_exposure: float = 1.0,
+                     **overrides) -> Constraints:
+    """Long-only bounds with the given exposure band."""
+    kwargs = dict(min_weights=pd.Series(0.0, index=TICKERS),
+                  max_weights=pd.Series(1.0, index=TICKERS),
+                  min_exposure=min_exposure,
+                  max_exposure=max_exposure)
+    kwargs.update(overrides)
+    return Constraints(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# the dispatch
+# --------------------------------------------------------------------------- #
+def test_a_fixed_exposure_routes_to_the_charnes_cooper_transform() -> None:
+    """Equal min and max exposure gives the equality constraint the transform needs."""
+    outcome = cvx_maximize_portfolio_sharpe(covar=covar_matrix(), means=means_vector(),
+                                            constraints=make_constraints(1.0, 1.0))
+    assert outcome.solver != 'SLSQP'
+    assert outcome.accepted
+
+
+def test_an_exposure_band_routes_to_the_scipy_fallback() -> None:
+    """Without an equality sum constraint the ratio has nothing to normalise against."""
+    outcome = cvx_maximize_portfolio_sharpe(covar=covar_matrix(), means=means_vector(),
+                                            constraints=make_constraints(0.5, 1.0))
+    assert outcome.solver == 'SLSQP'
+
+
+def test_both_paths_return_the_same_outcome_type() -> None:
+    """The caller cannot tell the paths apart from the return type, only from the solver."""
+    fixed = cvx_maximize_portfolio_sharpe(covar=covar_matrix(), means=means_vector(),
+                                          constraints=make_constraints(1.0, 1.0))
+    banded = cvx_maximize_portfolio_sharpe(covar=covar_matrix(), means=means_vector(),
+                                           constraints=make_constraints(0.5, 1.0))
+    assert type(fixed) is type(banded)
+    assert fixed.weights is not None and banded.weights is not None
+
+
+# --------------------------------------------------------------------------- #
+# the Charnes-Cooper path
+# --------------------------------------------------------------------------- #
+def test_the_transformed_solution_is_unscaled_back_onto_the_exposure() -> None:
+    """The auxiliary variable k must be divided out, or the weights are off by a constant.
+
+    Charnes-Cooper solves in ``z = k*w``; recovering ``w = z[:n] / z[n]`` is what puts the
+    answer back on the caller's exposure. A missed division still yields positive, ordered,
+    entirely plausible weights.
+    """
+    outcome = cvx_maximize_portfolio_sharpe(covar=covar_matrix(), means=means_vector(),
+                                            constraints=make_constraints(1.0, 1.0))
+    assert outcome.accepted
+    assert float(np.sum(outcome.weights)) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_the_transformed_solution_favours_the_best_reward_to_risk_asset() -> None:
+    """Asset A has the highest mean and B the second; the Sharpe optimum must not invert them."""
+    outcome = cvx_maximize_portfolio_sharpe(covar=covar_matrix(), means=means_vector(),
+                                            constraints=make_constraints(1.0, 1.0))
+    weights = pd.Series(outcome.weights, index=TICKERS)
+    assert weights['A'] > 0.0
+    assert weights.min() >= -1e-9                       # long-only bounds respected
+
+
+def test_a_solver_failure_on_the_transform_becomes_a_rejected_outcome(monkeypatch) -> None:
+    """CLARABEL can raise rather than report a status when the geometry is degenerate.
+
+    That must route into the same fallback as an honest infeasibility; propagating it would
+    kill a rolling backtest at one bad rebalancing date.
+    """
+    def fail(self, **kwargs):
+        """Stand in for a solver backend that raises instead of returning a status."""
+        raise cvx.error.SolverError('degenerate geometry')
+
+    monkeypatch.setattr(cvx.Problem, 'solve', fail)
+    outcome = cvx_maximize_portfolio_sharpe(covar=covar_matrix(), means=means_vector(),
+                                            constraints=make_constraints(1.0, 1.0))
+    assert not outcome.accepted
+    assert outcome.status == 'solver_error'
+
+
+# --------------------------------------------------------------------------- #
+# the SciPy fallback
+# --------------------------------------------------------------------------- #
+def test_the_scipy_path_respects_the_weight_bounds() -> None:
+    """SLSQP is given the same bounds and must return weights inside them."""
+    outcome = cvx_maximize_portfolio_sharpe(covar=covar_matrix(), means=means_vector(),
+                                            constraints=make_constraints(0.5, 1.0))
+    weights = np.asarray(outcome.weights, dtype=float)
+    assert weights.min() >= -1e-6
+    assert weights.max() <= 1.0 + 1e-6
+
+
+def test_the_scipy_objective_is_flat_at_zero_volatility() -> None:
+    """A zero-variance covariance makes the ratio undefined; the objective returns 0 instead.
+
+    Without that guard the first SLSQP evaluation divides by zero, and the optimiser walks off
+    into NaN rather than reporting a failure.
+    """
+    outcome = cvx_maximize_portfolio_sharpe(covar=np.zeros((4, 4)), means=means_vector(),
+                                            constraints=make_constraints(0.5, 1.0))
+    assert outcome.solver == 'SLSQP'
+    assert np.all(np.isfinite(np.asarray(outcome.weights, dtype=float)))
+
+
+# --------------------------------------------------------------------------- #
+# the wrapper
+# --------------------------------------------------------------------------- #
+def test_the_wrapper_returns_weights_indexed_by_ticker() -> None:
+    """The wrapper is the layer that puts the ticker index back on the solver's array."""
+    weights, outcome = wrapper_maximize_portfolio_sharpe(
+        pd_covar=pd.DataFrame(covar_matrix(), index=TICKERS, columns=TICKERS),
+        means=pd.Series(means_vector(), index=TICKERS),
+        constraints=make_constraints(1.0, 1.0))
+    assert list(weights.index) == list(TICKERS)
+    assert outcome.accepted

--- a/optimalportfolios/optimization/tests/max_sharpe_paths_test.py
+++ b/optimalportfolios/optimization/tests/max_sharpe_paths_test.py
@@ -107,13 +107,32 @@ def test_the_transformed_solution_is_unscaled_back_onto_the_exposure() -> None:
     assert float(np.sum(outcome.weights)) == pytest.approx(1.0, abs=1e-6)
 
 
-def test_the_transformed_solution_favours_the_best_reward_to_risk_asset() -> None:
-    """Asset A has the highest mean and B the second; the Sharpe optimum must not invert them."""
+def test_the_transformed_solution_beats_every_naive_alternative_on_sharpe() -> None:
+    """The recovered weights must actually maximise the ratio, not merely satisfy the bounds.
+
+    Optimality is the claim the transform makes, and it is the one thing box-and-exposure
+    assertions cannot see: a wrong ``k``, a dropped covariance term or a sign slip all leave
+    weights that are long-only, sum to one and look sensible. Scoring the result against the
+    equal-weight portfolio and against each single-asset portfolio is a cheap lower bound that
+    those failures do not clear. Deliberately not asserted: any ordering of the weights against
+    the means. The Sharpe optimum here is ordered D > C > B > A, the exact inverse of the means,
+    because the low-mean assets are the low-vol ones -- an intuition-shaped assertion would
+    pin the wrong portfolio.
+    """
     outcome = cvx_maximize_portfolio_sharpe(covar=covar_matrix(), means=means_vector(),
                                             constraints=make_constraints(1.0, 1.0))
     weights = pd.Series(outcome.weights, index=TICKERS)
-    assert weights['A'] > 0.0
     assert weights.min() >= -1e-9                       # long-only bounds respected
+
+    covar, means = covar_matrix(), means_vector()
+
+    def sharpe(w: np.ndarray) -> float:
+        """Reward-to-risk of a weight vector under the test covariance."""
+        return float(w @ means / np.sqrt(w @ covar @ w))
+
+    best = sharpe(weights.to_numpy())
+    assert best > sharpe(np.full(len(TICKERS), 1.0 / len(TICKERS)))
+    assert best > max(sharpe(row) for row in np.eye(len(TICKERS)))
 
 
 def test_a_solver_failure_on_the_transform_becomes_a_rejected_outcome(monkeypatch) -> None:

--- a/optimalportfolios/optimization/tests/maximise_alpha_with_target_yield_test.py
+++ b/optimalportfolios/optimization/tests/maximise_alpha_with_target_yield_test.py
@@ -1,107 +1,398 @@
-"""Regression tests for alpha maximisation with a target yield."""
+"""
+alpha maximisation under a hard yield floor, and the soft-TE branch that keeps it feasible.
 
+    max_w  alpha'(w - w_b)   s.t.  y'w >= r,  TE(w, w_b) <= budget,  box/turnover/group
+
+The interesting structure is the interaction between the two risk-side terms. A tight tracking
+-error budget and an aggressive yield floor can be jointly infeasible -- a low-yield-tilting
+alpha colliding with a high floor -- and the module offers two ways through that, selected by
+``soft_tracking_error``. With it off, TE is a hard constraint and the solve can legitimately
+come back infeasible. With it on, TE moves into the objective as a utility penalty while the
+yield floor stays hard, so the target wins.
+
+A populated ``tracking_err_vol_constraint`` is ignored on that second path -- in the solve and
+in ``validate_solution`` alike -- which is what
+``test_a_populated_hard_te_budget_is_ignored_by_the_soft_branch`` pins. The two have to agree:
+when the solve dropped the budget but validation still re-applied it, an ``optimal`` solve was
+rejected for violating a constraint it had been deliberately freed from, and every rebalance
+fell back to benchmark weights (issue #49). The test therefore asserts not just acceptance but
+that the weights equal the utility-only solve, so a budget silently left in force would show
+up as a different optimum rather than only as a different reported reason.
+
+That branch does something subtle enough to be worth a test of its own: the utility builder
+would penalise turnover as well, so the soft path nulls ``turnover_utility_weight`` and then
+re-adds turnover as a *hard* constraint. Get that wrong and turnover is either double-counted
+(penalised and constrained) or silently unconstrained. Both produce a solved portfolio.
+
+The objective also switches form on whether a benchmark is present -- active ``alpha'(w - w_b)``
+versus absolute ``alpha'w``. Since ``w_b`` is a constant, the two have the same argmax under
+identical constraints, so the tests assert the weights agree rather than pretending the switch
+changes the optimum; what it changes is the reported objective value.
+
+The yield floor itself is asserted as a floor: at the optimum the portfolio yield must reach
+the target, and raising the target must move the weights toward higher-yielding assets.
+"""
+# packages
+import cvxpy as cvx
 import numpy as np
 import pandas as pd
-
+import pytest
+# optimalportfolios
+from optimalportfolios.optimization.config import OptimiserConfig
 from optimalportfolios.optimization.constraints import Constraints
 from optimalportfolios.optimization.taa.maximise_alpha_with_target_yield import (
     cvx_maximise_alpha_with_target_return,
+    rolling_maximise_alpha_with_target_return,
+    wrapper_maximise_alpha_with_target_return,
 )
 
-
-TICKERS = pd.Index(["A", "B", "C", "D"])
-VOLS = np.array([0.20, 0.12, 0.08, 0.05])
-CORR = np.array([
-    [1.0, 0.3, 0.1, 0.0],
-    [0.3, 1.0, 0.2, 0.1],
-    [0.1, 0.2, 1.0, 0.25],
-    [0.0, 0.1, 0.25, 1.0],
-])
-COVAR = np.outer(VOLS, VOLS) * CORR
-ALPHAS = np.array([0.04, 0.02, -0.01, -0.02])
-YIELDS = pd.Series([0.01, 0.02, 0.04, 0.05], index=TICKERS)
-BENCHMARK = pd.Series(0.25, index=TICKERS)
+TICKERS = pd.Index(['A', 'B', 'C', 'D'])
+DATES = pd.DatetimeIndex(['2024-03-31', '2024-06-30'])
 
 
-def _constraints(
-        hard_te: float | None,
-        turnover: float | None = None,
-) -> Constraints:
-    """Create the issue-49 constraint geometry."""
-    return Constraints(
-        is_long_only=True,
-        min_weights=pd.Series(0.0, index=TICKERS),
-        max_weights=pd.Series(1.0, index=TICKERS),
-        min_exposure=1.0,
-        max_exposure=1.0,
-        asset_returns=YIELDS,
-        target_return=0.045,
-        benchmark_weights=BENCHMARK,
-        weights_0=BENCHMARK if turnover is not None else None,
-        turnover_constraint=turnover,
-        tracking_err_vol_constraint=hard_te,
-        tre_utility_weight=10.0,
-    )
+def covar_frame() -> pd.DataFrame:
+    """A well-conditioned 4-asset covariance in the canonical ticker order."""
+    vols = np.array([0.20, 0.12, 0.08, 0.05])
+    corr = np.array([
+        [1.00, 0.30, 0.10, 0.00],
+        [0.30, 1.00, 0.20, 0.10],
+        [0.10, 0.20, 1.00, 0.25],
+        [0.00, 0.10, 0.25, 1.00],
+    ])
+    return pd.DataFrame(np.outer(vols, vols) * corr, index=TICKERS, columns=TICKERS)
 
 
-def test_soft_tracking_error_ignores_a_populated_hard_budget() -> None:
-    """Soft TE accepts the solved geometry even when a hard budget is populated."""
-    with_hard_budget = cvx_maximise_alpha_with_target_return(
-        covar=COVAR,
-        alphas=ALPHAS,
-        constraints=_constraints(hard_te=0.0001),
-        soft_tracking_error=True,
-    )
-    utility_only = cvx_maximise_alpha_with_target_return(
-        covar=COVAR,
-        alphas=ALPHAS,
-        constraints=_constraints(hard_te=None),
-        soft_tracking_error=True,
-    )
-
-    assert with_hard_budget.status == "optimal"
-    assert with_hard_budget.accepted
-    assert with_hard_budget.fallback_source is None
-    assert float(YIELDS.to_numpy() @ with_hard_budget.weights) >= 0.045 - 1e-8
-    active_weights = with_hard_budget.weights - BENCHMARK.to_numpy()
-    tracking_error = float(np.sqrt(active_weights @ COVAR @ active_weights))
-    assert tracking_error > 0.0001
-    np.testing.assert_allclose(with_hard_budget.weights, utility_only.weights, atol=1e-7)
-    assert with_hard_budget.constraints is not None
-    assert with_hard_budget.constraints.tracking_err_vol_constraint is None
+def alphas_series() -> pd.Series:
+    """Alphas that prefer the low-yield end of the universe, so the floor genuinely binds."""
+    return pd.Series([0.04, 0.02, -0.01, -0.02], index=TICKERS)
 
 
-def test_hard_tracking_error_still_rejects_the_infeasible_geometry() -> None:
-    """The ordinary hard-TE path retains the conflicting hard budget."""
-    outcome = cvx_maximise_alpha_with_target_return(
-        covar=COVAR,
-        alphas=ALPHAS,
-        constraints=_constraints(hard_te=0.0001),
-        soft_tracking_error=False,
-    )
-
-    assert not outcome.accepted
-    assert outcome.fallback_source == "benchmark_weights"
-    np.testing.assert_allclose(outcome.weights, BENCHMARK.to_numpy())
+def yields_series() -> pd.Series:
+    """Yields ordered opposite to the alphas: A is the alpha pick and the worst carry."""
+    return pd.Series([0.01, 0.02, 0.04, 0.05], index=TICKERS)
 
 
-def test_soft_tracking_error_keeps_total_turnover_hard() -> None:
-    """Softening TE does not soften the separately re-added turnover budget."""
-    outcome = cvx_maximise_alpha_with_target_return(
-        covar=COVAR,
-        alphas=ALPHAS,
-        constraints=_constraints(hard_te=0.0001, turnover=1.0),
-        soft_tracking_error=True,
-    )
+def make_constraints(**overrides) -> Constraints:
+    """Long-only fully-invested bounds, with optional field overrides."""
+    kwargs = dict(min_weights=pd.Series(0.0, index=TICKERS),
+                  max_weights=pd.Series(1.0, index=TICKERS),
+                  min_exposure=1.0,
+                  max_exposure=1.0)
+    kwargs.update(overrides)
+    return Constraints(**kwargs)
 
+
+def prices_frame() -> pd.DataFrame:
+    """A price panel spanning the rebalancing dates, used for column alignment and drift."""
+    return pd.DataFrame(100.0, index=pd.date_range('2024-01-31', periods=8, freq='ME'),
+                        columns=TICKERS)
+
+
+# --------------------------------------------------------------------------- #
+# the yield floor
+# --------------------------------------------------------------------------- #
+def test_the_yield_target_is_reached_at_the_optimum() -> None:
+    """The floor binds: alphas prefer low-yield A, so the optimum sits on the constraint."""
+    target = 0.030
+    weights, outcome = wrapper_maximise_alpha_with_target_return(
+        pd_covar=covar_frame(), alphas=alphas_series(), yields=yields_series(),
+        target_return=target, constraints=make_constraints())
     assert outcome.accepted
-    turnover = float(np.abs(outcome.weights - BENCHMARK.to_numpy()).sum())
-    assert turnover <= 1.0 + 1e-4
-    turnover_residuals = [
-        residual
-        for residual in outcome.constraint_residuals
-        if residual.constraint_type == "turnover"
-    ]
-    assert len(turnover_residuals) == 1
-    assert turnover_residuals[0].hard
-    assert turnover_residuals[0].passed
+    assert float(weights @ yields_series()) >= target - 1e-6
+
+
+def test_a_higher_target_shifts_weight_toward_the_higher_yielding_assets() -> None:
+    """Raising the floor must buy carry, at the cost of alpha."""
+    common = dict(pd_covar=covar_frame(), alphas=alphas_series(), yields=yields_series(),
+                  constraints=make_constraints())
+    low, _ = wrapper_maximise_alpha_with_target_return(target_return=0.020, **common)
+    high, _ = wrapper_maximise_alpha_with_target_return(target_return=0.045, **common)
+    assert high[['C', 'D']].sum() > low[['C', 'D']].sum()
+    assert float(high @ alphas_series()) <= float(low @ alphas_series()) + 1e-9
+
+
+def test_a_nan_yield_is_treated_as_zero_with_a_warning() -> None:
+    """An asset with no yield estimate must not be credited toward the floor.
+
+    Filling with zero is the conservative choice and is warned about; filling with the mean
+    would let a missing estimate satisfy the target it was supposed to constrain.
+    """
+    yields = yields_series().copy()
+    yields['D'] = np.nan
+    with pytest.warns(UserWarning, match='NaN yields'):
+        weights, outcome = wrapper_maximise_alpha_with_target_return(
+            pd_covar=covar_frame(), alphas=alphas_series(), yields=yields,
+            target_return=0.020, constraints=make_constraints())
+    contributed = float(weights @ yields.fillna(0.0))
+    assert contributed >= 0.020 - 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# absolute vs active objective
+# --------------------------------------------------------------------------- #
+def test_without_a_benchmark_the_objective_is_absolute() -> None:
+    """No benchmark means the plain alpha'w problem -- the original behaviour."""
+    outcome = cvx_maximise_alpha_with_target_return(
+        covar=covar_frame().to_numpy(), alphas=alphas_series().to_numpy(),
+        constraints=make_constraints(asset_returns=yields_series(), target_return=0.020))
+    assert outcome.accepted
+
+
+def test_a_benchmark_switches_to_the_active_objective_without_moving_the_optimum() -> None:
+    """alpha'(w - w_b) and alpha'w differ by a constant, so they share an argmax.
+
+    The switch changes the reported objective value, not the portfolio; asserting the weights
+    match is what shows the benchmark is subtracted rather than, say, added.
+    """
+    benchmark = pd.Series(0.25, index=TICKERS)
+    absolute = cvx_maximise_alpha_with_target_return(
+        covar=covar_frame().to_numpy(), alphas=alphas_series().to_numpy(),
+        constraints=make_constraints(asset_returns=yields_series(), target_return=0.020))
+    active = cvx_maximise_alpha_with_target_return(
+        covar=covar_frame().to_numpy(), alphas=alphas_series().to_numpy(),
+        constraints=make_constraints(asset_returns=yields_series(), target_return=0.020,
+                                     benchmark_weights=benchmark))
+    np.testing.assert_allclose(absolute.weights, active.weights, atol=1e-5)
+
+
+# --------------------------------------------------------------------------- #
+# the soft tracking-error branch
+# --------------------------------------------------------------------------- #
+def test_soft_tracking_error_reaches_a_target_the_hard_path_cannot() -> None:
+    """The soft branch meets an aggressive yield floor where the hard TE budget goes infeasible.
+
+    This is the whole point of the branch: the floor stays hard and TE becomes a penalty, so
+    the target takes priority. Whether the caller also leaves a hard budget set is immaterial
+    to that -- see the tests below, which pin it either way.
+    """
+    benchmark = pd.Series(0.25, index=TICKERS)
+    covar, alphas = covar_frame().to_numpy(), alphas_series().to_numpy()
+
+    hard = cvx_maximise_alpha_with_target_return(
+        covar=covar, alphas=alphas, soft_tracking_error=False,
+        constraints=make_constraints(asset_returns=yields_series(), target_return=0.045,
+                                     benchmark_weights=benchmark,
+                                     tracking_err_vol_constraint=0.0001))
+    assert not hard.accepted and hard.status == 'infeasible'
+
+    soft = cvx_maximise_alpha_with_target_return(
+        covar=covar, alphas=alphas, soft_tracking_error=True,
+        constraints=make_constraints(asset_returns=yields_series(), target_return=0.045,
+                                     benchmark_weights=benchmark,
+                                     tre_utility_weight=10.0))
+    assert soft.accepted
+    assert float(soft.weights @ yields_series().to_numpy()) >= 0.045 - 1e-6
+
+
+def test_a_populated_hard_te_budget_is_ignored_by_the_soft_branch() -> None:
+    """Setting both ``tre_utility_weight`` and ``tracking_err_vol_constraint`` is accepted.
+
+    The budget is dropped from the CVXPY problem *and* from the constraints handed to
+    ``validate_solution``, so the two agree on which problem was solved. Comparing against the
+    utility-only geometry is the assertion that carries the weight: acceptance alone would
+    still pass if the budget were merely relaxed rather than removed, whereas identical weights
+    can only come from the same problem. The tracking error of that shared optimum is checked
+    to exceed the budget, so the case is one the budget would genuinely have rejected -- which
+    is what made issue #49 a silent fallback to benchmark weights on every rebalance.
+    """
+    benchmark = pd.Series(0.25, index=TICKERS)
+    covar, alphas = covar_frame().to_numpy(), alphas_series().to_numpy()
+    soft = dict(asset_returns=yields_series(), target_return=0.045,
+                benchmark_weights=benchmark, tre_utility_weight=10.0)
+
+    with_budget = cvx_maximise_alpha_with_target_return(
+        covar=covar, alphas=alphas, soft_tracking_error=True,
+        constraints=make_constraints(tracking_err_vol_constraint=0.0001, **soft))
+    utility_only = cvx_maximise_alpha_with_target_return(
+        covar=covar, alphas=alphas, soft_tracking_error=True,
+        constraints=make_constraints(**soft))
+
+    assert with_budget.status == 'optimal'
+    assert with_budget.accepted
+    assert with_budget.fallback_source is None
+    np.testing.assert_allclose(with_budget.weights, utility_only.weights, atol=1e-7)
+    assert with_budget.constraints is not None
+    assert with_budget.constraints.tracking_err_vol_constraint is None
+    active = with_budget.weights - benchmark.to_numpy()
+    assert float(np.sqrt(active @ covar @ active)) > 0.0001
+    assert float(with_budget.weights @ yields_series().to_numpy()) >= 0.045 - 1e-8
+
+
+def test_the_hard_path_still_rejects_that_same_geometry() -> None:
+    """Softening TE is opt-in: with the flag off the budget binds and the fallback stands.
+
+    The pair with the test above is the point -- the same constraints must reach opposite
+    outcomes depending only on ``soft_tracking_error``, which is what shows the fix loosened
+    the soft branch rather than the budget everywhere.
+    """
+    benchmark = pd.Series(0.25, index=TICKERS)
+    outcome = cvx_maximise_alpha_with_target_return(
+        covar=covar_frame().to_numpy(), alphas=alphas_series().to_numpy(),
+        soft_tracking_error=False,
+        constraints=make_constraints(asset_returns=yields_series(), target_return=0.045,
+                                     benchmark_weights=benchmark,
+                                     tracking_err_vol_constraint=0.0001,
+                                     tre_utility_weight=10.0))
+    assert not outcome.accepted
+    assert outcome.fallback_source == 'benchmark_weights'
+    np.testing.assert_allclose(outcome.weights, benchmark.to_numpy())
+
+
+def test_the_soft_branch_requires_a_benchmark_to_engage() -> None:
+    """``soft_tracking_error`` without a benchmark falls through to the hard path.
+
+    There is no TE to soften without ``w_b``, so the flag is inert rather than an error.
+    """
+    outcome = cvx_maximise_alpha_with_target_return(
+        covar=covar_frame().to_numpy(), alphas=alphas_series().to_numpy(),
+        constraints=make_constraints(asset_returns=yields_series(), target_return=0.020),
+        soft_tracking_error=True)
+    assert outcome.accepted
+
+
+def test_the_soft_branch_keeps_turnover_hard_rather_than_double_counting_it() -> None:
+    """Turnover is nulled in the utility objective and re-added as a hard bound.
+
+    If the nulling were dropped, turnover would be both penalised and constrained; if the
+    re-add were dropped, it would be unconstrained. Either way the solve still succeeds, so
+    the binding budget is what has to be checked -- and checked twice: the realised L1 move
+    against the budget, and the recorded residual, which is where a turnover term demoted to a
+    penalty (or dropped) would show up as a missing or non-hard entry.
+    """
+    benchmark = pd.Series(0.25, index=TICKERS)
+    weights_0 = pd.Series([1.0, 0.0, 0.0, 0.0], index=TICKERS)
+    # starting wholly in the lowest-yielding asset, reaching a 2% floor needs to move >= 0.25
+    # out of A, i.e. an L1 budget above 0.50; a tighter budget is infeasible for the floor
+    # rather than binding on it, which would test nothing.
+    budget = 0.60
+    constraints = make_constraints(asset_returns=yields_series(), target_return=0.020,
+                                   benchmark_weights=benchmark,
+                                   tre_utility_weight=10.0,
+                                   turnover_utility_weight=5.0,
+                                   weights_0=weights_0,
+                                   turnover_constraint=budget)
+    outcome = cvx_maximise_alpha_with_target_return(
+        covar=covar_frame().to_numpy(), alphas=alphas_series().to_numpy(),
+        constraints=constraints, soft_tracking_error=True)
+    assert outcome.accepted
+    turnover = float(np.sum(np.abs(outcome.weights - weights_0.to_numpy())))
+    assert turnover <= budget + 1e-5
+    residuals = [residual for residual in outcome.constraint_residuals
+                 if residual.constraint_type == 'turnover']
+    assert len(residuals) == 1
+    assert residuals[0].hard
+    assert residuals[0].passed
+
+
+def test_the_soft_branch_warns_when_turnover_has_no_starting_weights() -> None:
+    """A turnover budget without ``weights_0`` cannot be enforced, and says so."""
+    benchmark = pd.Series(0.25, index=TICKERS)
+    constraints = make_constraints(asset_returns=yields_series(), target_return=0.020,
+                                   benchmark_weights=benchmark,
+                                   tre_utility_weight=10.0,
+                                   turnover_constraint=0.30)
+    with pytest.warns(UserWarning, match='weights_0 must be given'):
+        cvx_maximise_alpha_with_target_return(
+            covar=covar_frame().to_numpy(), alphas=alphas_series().to_numpy(),
+            constraints=constraints, soft_tracking_error=True)
+
+
+def test_the_soft_branch_honours_per_asset_turnover_costs() -> None:
+    """With costs set, the hard turnover bound is cost-weighted rather than plain L1."""
+    benchmark = pd.Series(0.25, index=TICKERS)
+    weights_0 = pd.Series([1.0, 0.0, 0.0, 0.0], index=TICKERS)
+    costs = pd.Series([2.0, 1.0, 1.0, 1.0], index=TICKERS)
+    constraints = make_constraints(asset_returns=yields_series(), target_return=0.020,
+                                   benchmark_weights=benchmark,
+                                   tre_utility_weight=10.0,
+                                   weights_0=weights_0,
+                                   turnover_costs=costs,
+                                   turnover_constraint=1.00)
+    outcome = cvx_maximise_alpha_with_target_return(
+        covar=covar_frame().to_numpy(), alphas=alphas_series().to_numpy(),
+        constraints=constraints, soft_tracking_error=True)
+    assert outcome.accepted
+    weighted = float(np.sum(np.abs(costs.to_numpy() * (outcome.weights - weights_0.to_numpy()))))
+    assert weighted <= 1.00 + 1e-5
+
+
+# --------------------------------------------------------------------------- #
+# solver failure
+# --------------------------------------------------------------------------- #
+def test_a_solver_failure_becomes_a_rejected_outcome(monkeypatch) -> None:
+    """A degenerate yield/alpha geometry can make CLARABEL raise instead of report.
+
+    The rolling layer calls this once per rebalancing date, so it must degrade to a recorded
+    non-accepted outcome rather than propagate and kill the run.
+    """
+    def fail(self, **kwargs):
+        """Stand in for a solver backend that raises instead of returning a status."""
+        raise cvx.error.SolverError('degenerate geometry')
+
+    monkeypatch.setattr(cvx.Problem, 'solve', fail)
+    outcome = cvx_maximise_alpha_with_target_return(
+        covar=covar_frame().to_numpy(), alphas=alphas_series().to_numpy(),
+        constraints=make_constraints(asset_returns=yields_series(), target_return=0.020))
+    assert not outcome.accepted
+    assert outcome.status == 'solver_error'
+
+
+# --------------------------------------------------------------------------- #
+# the rolling layer
+# --------------------------------------------------------------------------- #
+def rolling_inputs(**overrides) -> dict:
+    """Panel inputs for the rolling solver over the two rebalancing dates."""
+    kwargs = dict(prices=prices_frame(),
+                  alphas=pd.DataFrame([alphas_series()] * len(DATES), index=DATES),
+                  yields=pd.DataFrame([yields_series()] * len(DATES), index=DATES),
+                  target_returns=pd.Series(0.020, index=DATES),
+                  constraints=make_constraints(),
+                  covar_dict={date: covar_frame() for date in DATES})
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_the_rolling_solver_returns_one_row_per_rebalancing_date() -> None:
+    """The covariance dict's keys define the schedule, and the output follows it."""
+    weights = rolling_maximise_alpha_with_target_return(**rolling_inputs())
+    assert list(weights.index) == list(DATES)
+    assert list(weights.columns) == list(TICKERS)
+
+
+def test_a_static_benchmark_series_is_broadcast_over_the_schedule() -> None:
+    """A Series benchmark is transposed and forward-filled onto every rebalancing date."""
+    weights = rolling_maximise_alpha_with_target_return(
+        **rolling_inputs(benchmark_weights=pd.Series(0.25, index=TICKERS)))
+    assert list(weights.index) == list(DATES)
+    assert not weights.isna().any().any()
+
+
+def test_a_time_varying_benchmark_frame_is_forward_filled() -> None:
+    """A DataFrame benchmark starting before the schedule is carried forward, not dropped."""
+    frame = pd.DataFrame([[0.25, 0.25, 0.25, 0.25]],
+                         index=pd.DatetimeIndex(['2024-01-31']), columns=TICKERS)
+    weights = rolling_maximise_alpha_with_target_return(
+        **rolling_inputs(benchmark_weights=frame))
+    assert list(weights.index) == list(DATES)
+
+
+def test_alphas_and_yields_are_forward_filled_onto_the_schedule() -> None:
+    """Inputs on a slower cadence than the covariances are ffilled, not reindexed to NaN."""
+    sparse_dates = pd.DatetimeIndex(['2024-01-31'])
+    weights = rolling_maximise_alpha_with_target_return(
+        **rolling_inputs(
+            alphas=pd.DataFrame([alphas_series()], index=sparse_dates),
+            yields=pd.DataFrame([yields_series()], index=sparse_dates),
+            target_returns=pd.Series(0.020, index=sparse_dates)))
+    assert list(weights.index) == list(DATES)
+    assert not weights.isna().any().any()
+
+
+def test_the_verbose_config_prints_per_date_diagnostics(capsys) -> None:
+    """``verbose`` is threaded into the rolling loop, not only into the solver."""
+    rolling_maximise_alpha_with_target_return(
+        **rolling_inputs(optimiser_config=OptimiserConfig(apply_total_to_good_ratio=True,
+                                                          verbose=True)))
+    printed = capsys.readouterr().out
+    assert 'date=' in printed
+    assert 'pd_covar=' in printed

--- a/optimalportfolios/optimization/tests/minimum_tracking_error_guards_test.py
+++ b/optimalportfolios/optimization/tests/minimum_tracking_error_guards_test.py
@@ -1,0 +1,263 @@
+"""
+input validation across the three minimum-tracking-error entry points.
+
+Every guard here stands between a caller mistake and a solve that succeeds on the wrong
+problem. That is the specific hazard of a TRE objective: ``(w - w_b)' Sigma (w - w_b)`` is
+perfectly well-defined for a benchmark that is silently misaligned, truncated, or carrying a
+NaN filled in as zero -- CVXPY returns weights, ``validate_solution`` accepts them, and the
+portfolio tracks something nobody asked for. So each of these raises rather than repairing.
+
+The three layers validate different things and are tested separately for that reason. The
+rolling layer owns benchmark *shape* across time (Series broadcast vs DataFrame forward-fill);
+the wrapper owns the covariance's own well-formedness after NaN filtering; the CVXPY layer
+re-checks the raw array it is handed, because it is public and callable without either wrapper.
+
+The solver-failure fallback is covered too: a ``SolverError`` must come back as a non-accepted
+outcome with a recorded status, never as an exception escaping into the backtest loop.
+"""
+# packages
+import cvxpy as cvx
+import numpy as np
+import pandas as pd
+import pytest
+# optimalportfolios
+from optimalportfolios.optimization.constraints import Constraints
+from optimalportfolios.optimization.general.minimum_tracking_error import (
+    cvx_minimise_tracking_error,
+    rolling_minimise_tracking_error,
+    wrapper_minimise_tracking_error,
+)
+
+TICKERS = pd.Index(['A', 'B', 'C', 'D'])
+DATES = pd.DatetimeIndex(['2024-03-31', '2024-06-30'])
+
+
+def covar_frame() -> pd.DataFrame:
+    """A well-conditioned 4-asset covariance in the canonical ticker order."""
+    vols = np.array([0.20, 0.12, 0.08, 0.05])
+    corr = np.array([
+        [1.00, 0.30, 0.10, 0.00],
+        [0.30, 1.00, 0.20, 0.10],
+        [0.10, 0.20, 1.00, 0.25],
+        [0.00, 0.10, 0.25, 1.00],
+    ])
+    return pd.DataFrame(np.outer(vols, vols) * corr, index=TICKERS, columns=TICKERS)
+
+
+def benchmark() -> pd.Series:
+    """An equal-weight benchmark over the four tickers."""
+    return pd.Series(0.25, index=TICKERS)
+
+
+def make_constraints(**overrides) -> Constraints:
+    """Long-only bounds carrying the benchmark, with optional field overrides."""
+    kwargs = dict(min_weights=pd.Series(0.0, index=TICKERS),
+                  max_weights=pd.Series(1.0, index=TICKERS),
+                  benchmark_weights=benchmark())
+    kwargs.update(overrides)
+    return Constraints(**kwargs)
+
+
+def prices_frame() -> pd.DataFrame:
+    """A price panel spanning the rebalancing dates, used only for column alignment."""
+    return pd.DataFrame(100.0, index=pd.date_range('2024-01-31', periods=8, freq='ME'),
+                        columns=TICKERS)
+
+
+# --------------------------------------------------------------------------- #
+# rolling_minimise_tracking_error
+# --------------------------------------------------------------------------- #
+def test_an_empty_rebalancing_schedule_returns_an_empty_frame() -> None:
+    """No covariance dates means no weights -- an empty frame, not an error or a NaN row."""
+    weights = rolling_minimise_tracking_error(prices=prices_frame(),
+                                              constraints=make_constraints(),
+                                              benchmark_weights=benchmark(),
+                                              covar_dict={})
+    assert weights.empty
+    assert list(weights.columns) == list(TICKERS)
+    assert isinstance(weights.index, pd.DatetimeIndex)
+
+
+def test_a_static_benchmark_series_is_broadcast_over_every_rebalance() -> None:
+    """A Series benchmark applies unchanged at each date; a DataFrame is forward-filled."""
+    covar_dict = {date: covar_frame() for date in DATES}
+    weights = rolling_minimise_tracking_error(prices=prices_frame(),
+                                              constraints=make_constraints(),
+                                              benchmark_weights=benchmark(),
+                                              covar_dict=covar_dict)
+    assert list(weights.index) == list(DATES)
+    assert not weights.isna().any().any()
+
+
+def test_a_time_varying_benchmark_frame_is_forward_filled() -> None:
+    """A DataFrame benchmark is reindexed onto the rebalancing dates by ffill."""
+    frame = pd.DataFrame([[0.25, 0.25, 0.25, 0.25]],
+                         index=pd.DatetimeIndex(['2024-01-31']), columns=TICKERS)
+    covar_dict = {date: covar_frame() for date in DATES}
+    weights = rolling_minimise_tracking_error(prices=prices_frame(),
+                                              constraints=make_constraints(),
+                                              benchmark_weights=frame,
+                                              covar_dict=covar_dict)
+    assert list(weights.index) == list(DATES)
+
+
+def test_inclusion_indicators_are_aligned_onto_the_rebalancing_dates() -> None:
+    """An eligibility panel is forward-filled and column-aligned like the benchmark."""
+    indicators = pd.DataFrame(1.0, index=pd.DatetimeIndex(['2024-01-31']), columns=TICKERS)
+    covar_dict = {date: covar_frame() for date in DATES}
+    weights = rolling_minimise_tracking_error(prices=prices_frame(),
+                                              constraints=make_constraints(),
+                                              benchmark_weights=benchmark(),
+                                              covar_dict=covar_dict,
+                                              inclusion_indicators=indicators)
+    assert list(weights.index) == list(DATES)
+
+
+def test_a_benchmark_that_is_neither_series_nor_frame_raises() -> None:
+    """A dict or array benchmark would broadcast in some silently wrong way."""
+    with pytest.raises(TypeError, match='must be a Series or DataFrame'):
+        rolling_minimise_tracking_error(prices=prices_frame(),
+                                        constraints=make_constraints(),
+                                        benchmark_weights={'A': 0.25},
+                                        covar_dict={DATES[0]: covar_frame()})
+
+
+def test_a_benchmark_missing_a_ticker_raises_rather_than_filling_zero() -> None:
+    """Reindexing onto the price columns introduces NaN, which must not become a 0% target."""
+    partial = benchmark().drop('D')
+    with pytest.raises(ValueError, match='finite and complete at every rebalance'):
+        rolling_minimise_tracking_error(prices=prices_frame(),
+                                        constraints=make_constraints(),
+                                        benchmark_weights=partial,
+                                        covar_dict={DATES[0]: covar_frame()})
+
+
+# --------------------------------------------------------------------------- #
+# wrapper_minimise_tracking_error
+# --------------------------------------------------------------------------- #
+def test_the_wrapper_solves_and_returns_an_accepted_outcome() -> None:
+    """The happy path returns weights over the ticker index and an accepted outcome."""
+    weights, outcome = wrapper_minimise_tracking_error(pd_covar=covar_frame(),
+                                                       benchmark_weights=benchmark(),
+                                                       constraints=make_constraints())
+    assert list(weights.index) == list(TICKERS)
+    assert outcome.accepted
+
+
+@pytest.mark.parametrize('bad_covar', [
+    pd.DataFrame(),
+    'not a frame',
+])
+def test_a_missing_or_empty_covariance_raises(bad_covar) -> None:
+    """An empty frame is the shape a caller gets from slicing on a date with no estimate."""
+    with pytest.raises(ValueError, match='must be a non-empty DataFrame'):
+        wrapper_minimise_tracking_error(pd_covar=bad_covar,
+                                        benchmark_weights=benchmark(),
+                                        constraints=make_constraints())
+
+
+def test_a_covariance_whose_rows_and_columns_disagree_raises() -> None:
+    """Row/column order must match: a transposed or reordered covariance is not detectable later."""
+    covar = covar_frame()
+    covar.columns = pd.Index(['B', 'A', 'C', 'D'])
+    with pytest.raises(ValueError, match='index and columns must match'):
+        wrapper_minimise_tracking_error(pd_covar=covar,
+                                        benchmark_weights=benchmark(),
+                                        constraints=make_constraints())
+
+
+def test_a_non_finite_covariance_entry_raises() -> None:
+    """An infinity survives NaN filtering and would poison the objective."""
+    covar = covar_frame()
+    covar.iloc[0, 0] = np.inf
+    with pytest.raises(ValueError, match='pd_covar must be finite'):
+        wrapper_minimise_tracking_error(pd_covar=covar,
+                                        benchmark_weights=benchmark(),
+                                        constraints=make_constraints())
+
+
+def test_an_asymmetric_covariance_raises() -> None:
+    """Asymmetry means the quadratic form is not the risk the caller thinks it is."""
+    covar = covar_frame()
+    covar.iloc[0, 1] += 0.05
+    with pytest.raises(ValueError, match='pd_covar must be symmetric'):
+        wrapper_minimise_tracking_error(pd_covar=covar,
+                                        benchmark_weights=benchmark(),
+                                        constraints=make_constraints())
+
+
+def test_a_benchmark_with_a_nan_raises_at_the_wrapper() -> None:
+    """After NaN filtering the benchmark must still be complete over the surviving assets."""
+    bad = benchmark().copy()
+    bad['B'] = np.nan
+    with pytest.raises(ValueError, match='benchmark_weights must be finite and complete'):
+        wrapper_minimise_tracking_error(pd_covar=covar_frame(),
+                                        benchmark_weights=bad,
+                                        constraints=make_constraints())
+
+
+def test_incomplete_starting_weights_raise() -> None:
+    """``weights_0`` drives turnover terms, so a NaN there silently frees the turnover budget."""
+    weights_0 = benchmark().copy()
+    weights_0['C'] = np.nan
+    with pytest.raises(ValueError, match='weights_0 must be finite and complete'):
+        wrapper_minimise_tracking_error(pd_covar=covar_frame(),
+                                        benchmark_weights=benchmark(),
+                                        constraints=make_constraints(),
+                                        weights_0=weights_0)
+
+
+# --------------------------------------------------------------------------- #
+# cvx_minimise_tracking_error
+# --------------------------------------------------------------------------- #
+def test_the_cvx_layer_solves_a_well_posed_problem() -> None:
+    """Called directly with a raw array, the solver returns an accepted outcome."""
+    outcome = cvx_minimise_tracking_error(covar=covar_frame().to_numpy(),
+                                          constraints=make_constraints())
+    assert outcome.accepted
+
+
+def test_the_cvx_layer_rejects_a_non_square_covariance() -> None:
+    """This entry point is public, so it re-checks what the wrapper would have caught."""
+    with pytest.raises(ValueError, match='covar must be a square matrix'):
+        cvx_minimise_tracking_error(covar=np.ones((3, 4)), constraints=make_constraints())
+
+
+def test_the_cvx_layer_rejects_a_non_finite_covariance() -> None:
+    """A NaN reaching CVXPY produces an unbounded or infeasible status, not a clear error."""
+    covar = covar_frame().to_numpy().copy()
+    covar[2, 2] = np.nan
+    with pytest.raises(ValueError, match='covar must be finite'):
+        cvx_minimise_tracking_error(covar=covar, constraints=make_constraints())
+
+
+def test_the_cvx_layer_requires_benchmark_weights_on_the_constraints() -> None:
+    """There is no benchmark argument here: it travels on the constraints or not at all."""
+    with pytest.raises(ValueError, match='constraints.benchmark_weights is required'):
+        cvx_minimise_tracking_error(covar=covar_frame().to_numpy(),
+                                    constraints=make_constraints(benchmark_weights=None))
+
+
+def test_a_benchmark_of_the_wrong_length_raises() -> None:
+    """A benchmark over a different universe would broadcast or truncate silently."""
+    short = pd.Series(1.0 / 3.0, index=pd.Index(['A', 'B', 'C']))
+    with pytest.raises(ValueError, match='length does not match covariance'):
+        cvx_minimise_tracking_error(covar=covar_frame().to_numpy(),
+                                    constraints=make_constraints(benchmark_weights=short))
+
+
+def test_a_solver_failure_becomes_a_rejected_outcome_not_an_exception(monkeypatch) -> None:
+    """A SolverError must not escape into the backtest loop.
+
+    The rolling layer calls this once per rebalancing date; an exception there aborts the whole
+    backtest, whereas a recorded non-accepted outcome lets the caller fall back for that date.
+    """
+    def fail(self, **kwargs):
+        """Stand in for a solver that errors out."""
+        raise cvx.error.SolverError('solver failed')
+
+    monkeypatch.setattr(cvx.Problem, 'solve', fail)
+    outcome = cvx_minimise_tracking_error(covar=covar_frame().to_numpy(),
+                                          constraints=make_constraints())
+    assert not outcome.accepted
+    assert outcome.status == 'solver_error'

--- a/optimalportfolios/optimization/tests/risk_budgeting_solver_guards_test.py
+++ b/optimalportfolios/optimization/tests/risk_budgeting_solver_guards_test.py
@@ -1,0 +1,234 @@
+"""
+input validation and infeasibility detection in the constrained risk-budgeting solver.
+
+This solver minimises a log-barrier objective whose domain is the strictly positive orthant,
+then recovers the fully-invested solution by root-finding on the barrier multiplier. Both
+halves of that construction fail badly on inputs a portfolio caller can plausibly supply, and
+neither failure is loud on its own:
+
+- a zero or negative variance on the diagonal makes the risk contribution undefined, and a
+  negative lower bound puts the barrier's ``log(x)`` outside its domain -- so those are
+  rejected up front rather than left to produce NaNs mid-iteration;
+- a box whose lower bounds already sum above 1 (or whose upper bounds sum below 1) has no
+  fully-invested point at all, which the root-finder would otherwise chase to a bracketing
+  failure several hundred iterations later.
+
+``_validate_inputs`` deliberately runs on the *raw* inputs, before budget normalisation and
+before any slicing, because the caller's fallback contract is that every invalid input raises
+``ValueError``. The tests below go through the public entry point rather than calling the
+private validator, so they exercise that ordering as well as the messages.
+
+The pinned-box short circuit and the bracketing failure are the two non-validation paths here.
+A fully pinned box is not solved at all -- the weights are determined -- and the returned
+multiplier is NaN by contract, which callers must not read as a solve failure.
+"""
+# packages
+import numpy as np
+import pytest
+# optimalportfolios
+from optimalportfolios.optimization.general.risk_budgeting_solver import (
+    solve_constrained_risk_budgeting,
+)
+
+N = 4
+
+
+def covar_matrix() -> np.ndarray:
+    """A well-conditioned 4-asset covariance."""
+    vols = np.array([0.20, 0.12, 0.08, 0.05])
+    corr = np.array([
+        [1.00, 0.30, 0.10, 0.00],
+        [0.30, 1.00, 0.20, 0.10],
+        [0.10, 0.20, 1.00, 0.25],
+        [0.00, 0.10, 0.25, 1.00],
+    ])
+    return np.outer(vols, vols) * corr
+
+
+def equal_budgets() -> np.ndarray:
+    """Equal risk budgets over the four assets."""
+    return np.ones(N) / N
+
+
+# --------------------------------------------------------------------------- #
+# the happy path, for reference
+# --------------------------------------------------------------------------- #
+def test_the_solution_is_fully_invested_and_returns_a_positive_multiplier() -> None:
+    """Equal risk budgets give positive weights summing to one and a real multiplier."""
+    weights, lam = solve_constrained_risk_budgeting(covar=covar_matrix(),
+                                                    budgets=equal_budgets())
+    assert float(np.sum(weights)) == pytest.approx(1.0, abs=1e-6)
+    assert np.all(weights > 0.0)
+    assert lam > 0.0
+
+
+def test_budgets_default_to_equal_when_omitted() -> None:
+    """``budgets=None`` means equal risk contribution, the usual entry point."""
+    omitted, _ = solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=None)
+    explicit, _ = solve_constrained_risk_budgeting(covar=covar_matrix(),
+                                                   budgets=equal_budgets())
+    np.testing.assert_allclose(omitted, explicit, atol=1e-8)
+
+
+def test_budgets_are_normalised_rather_than_required_to_sum_to_one() -> None:
+    """Only the relative budgets matter, so an unnormalised vector is accepted."""
+    normalised, _ = solve_constrained_risk_budgeting(covar=covar_matrix(),
+                                                     budgets=equal_budgets())
+    scaled, _ = solve_constrained_risk_budgeting(covar=covar_matrix(),
+                                                 budgets=7.0 * equal_budgets())
+    np.testing.assert_allclose(normalised, scaled, atol=1e-8)
+
+
+# --------------------------------------------------------------------------- #
+# covariance validation
+# --------------------------------------------------------------------------- #
+def test_a_non_square_covariance_raises() -> None:
+    """The commonest caller error: a panel slice rather than a covariance."""
+    with pytest.raises(ValueError, match='covar must be square'):
+        solve_constrained_risk_budgeting(covar=np.ones((3, 4)), budgets=np.ones(3) / 3)
+
+
+def test_a_non_finite_covariance_raises_and_counts_the_offenders() -> None:
+    """The message carries the count, since one NaN and a whole NaN row differ in cause."""
+    covar = covar_matrix()
+    covar[0, 1] = np.nan
+    with pytest.raises(ValueError, match='non-finite values'):
+        solve_constrained_risk_budgeting(covar=covar, budgets=equal_budgets())
+
+
+@pytest.mark.parametrize('variance', [0.0, -0.01])
+def test_a_non_positive_variance_on_the_diagonal_raises(variance: float) -> None:
+    """A zero-variance asset makes its risk contribution undefined, not merely small.
+
+    The log-barrier objective divides through the risk contribution, so this would surface as
+    a NaN mid-iteration rather than as a rejected input.
+    """
+    covar = covar_matrix()
+    covar[2, 2] = variance
+    with pytest.raises(ValueError, match='diagonal must be strictly positive'):
+        solve_constrained_risk_budgeting(covar=covar, budgets=equal_budgets())
+
+
+# --------------------------------------------------------------------------- #
+# budget validation
+# --------------------------------------------------------------------------- #
+def test_budgets_of_the_wrong_length_raise() -> None:
+    """A budget vector over a different universe would broadcast or truncate silently."""
+    with pytest.raises(ValueError, match=r'budgets must have shape \(4,\)'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=np.ones(3) / 3)
+
+
+@pytest.mark.parametrize('bad', [
+    np.array([0.25, 0.25, -0.25, 0.75]),
+    np.array([0.25, 0.25, np.nan, 0.25]),
+])
+def test_negative_or_non_finite_budgets_raise(bad: np.ndarray) -> None:
+    """A negative risk budget has no meaning; a NaN one silently drops an asset."""
+    with pytest.raises(ValueError, match='budgets must be finite and non-negative'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=bad)
+
+
+def test_all_zero_budgets_raise_rather_than_dividing_by_zero() -> None:
+    """Budgets are normalised by their sum, so a zero sum must be caught first."""
+    with pytest.raises(ValueError, match='budgets must have a positive sum'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=np.zeros(N))
+
+
+# --------------------------------------------------------------------------- #
+# box validation
+# --------------------------------------------------------------------------- #
+def test_bounds_of_the_wrong_shape_raise() -> None:
+    """Bounds are (n, 2); a transposed array is the likely mistake."""
+    with pytest.raises(ValueError, match=r'bounds must have shape \(4, 2\)'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=equal_budgets(),
+                                         bounds=np.zeros((2, N)))
+
+
+def test_a_lower_bound_above_its_upper_bound_raises_and_names_the_asset() -> None:
+    """An inverted box is empty for that asset; the message identifies which."""
+    bounds = np.column_stack([np.zeros(N), np.full(N, 0.5)])
+    bounds[2, :] = [0.6, 0.4]
+    with pytest.raises(ValueError, match='lower bound exceeds upper bound at index 2'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=equal_budgets(),
+                                         bounds=bounds)
+
+
+def test_a_negative_lower_bound_raises_as_outside_the_barrier_domain() -> None:
+    """The log-barrier is defined on positive weights, so shorting is not merely unsupported.
+
+    A negative lower bound would let the iteration step into ``log`` of a negative number.
+    """
+    bounds = np.column_stack([np.zeros(N), np.full(N, 0.5)])
+    bounds[1, 0] = -0.10
+    with pytest.raises(ValueError, match='log-barrier domain'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=equal_budgets(),
+                                         bounds=bounds)
+
+
+def test_lower_bounds_summing_above_one_are_infeasible() -> None:
+    """No fully-invested point exists, which the root-finder would otherwise chase for a while."""
+    bounds = np.column_stack([np.full(N, 0.40), np.full(N, 0.60)])
+    with pytest.raises(ValueError, match='sum of lower bounds exceeds 1'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=equal_budgets(),
+                                         bounds=bounds)
+
+
+def test_upper_bounds_summing_below_one_are_infeasible() -> None:
+    """The mirror case: the box cannot reach full investment."""
+    bounds = np.column_stack([np.zeros(N), np.full(N, 0.10)])
+    with pytest.raises(ValueError, match='sum of upper bounds is below 1'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=equal_budgets(),
+                                         bounds=bounds)
+
+
+def test_a_fully_pinned_box_short_circuits_with_a_nan_multiplier() -> None:
+    """When lo == hi the weights are determined, so there is nothing to solve.
+
+    The multiplier is NaN by contract here. Callers must read that as "not applicable", not as
+    a failed solve -- it is the one accepted return with a non-finite second element.
+    """
+    pinned = np.full(N, 0.25)
+    bounds = np.column_stack([pinned, pinned])
+    weights, lam = solve_constrained_risk_budgeting(covar=covar_matrix(),
+                                                    budgets=equal_budgets(), bounds=bounds)
+    np.testing.assert_allclose(weights, pinned, atol=1e-9)
+    assert np.isnan(lam)
+
+
+# --------------------------------------------------------------------------- #
+# linear inequality validation
+# --------------------------------------------------------------------------- #
+def test_the_solver_accepts_a_linear_inequality_block() -> None:
+    """``C x <= d`` routes through the ADMM path and still returns a fully-invested solution."""
+    c_rows = np.array([[1.0, 1.0, 0.0, 0.0]])
+    c_lhs = np.array([0.60])
+    weights, _ = solve_constrained_risk_budgeting(covar=covar_matrix(),
+                                                  budgets=equal_budgets(),
+                                                  c_rows=c_rows, c_lhs=c_lhs)
+    assert float(np.sum(weights)) == pytest.approx(1.0, abs=1e-5)
+    assert float(weights[:2].sum()) <= 0.60 + 1e-5
+
+
+@pytest.mark.parametrize('c_rows, c_lhs', [
+    (np.array([[1.0, 1.0, 0.0, 0.0]]), None),
+    (None, np.array([0.60])),
+])
+def test_a_half_specified_inequality_block_raises(c_rows, c_lhs) -> None:
+    """A matrix without a right-hand side (or the reverse) is silently ignorable otherwise."""
+    with pytest.raises(ValueError, match='must both be given or both be None'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=equal_budgets(),
+                                         c_rows=c_rows, c_lhs=c_lhs)
+
+
+def test_an_inequality_matrix_with_the_wrong_width_raises() -> None:
+    """``C`` has one column per asset; anything else is a universe mismatch."""
+    with pytest.raises(ValueError, match=r'c_rows must have shape \(p, 4\)'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=equal_budgets(),
+                                         c_rows=np.ones((1, 3)), c_lhs=np.array([0.60]))
+
+
+def test_a_right_hand_side_of_the_wrong_length_raises() -> None:
+    """One bound per inequality row; a mismatch would zip them wrongly."""
+    with pytest.raises(ValueError, match=r'c_lhs must have shape \(1,\)'):
+        solve_constrained_risk_budgeting(covar=covar_matrix(), budgets=equal_budgets(),
+                                         c_rows=np.ones((1, N)), c_lhs=np.array([0.6, 0.7]))

--- a/optimalportfolios/tests/local_path_test.py
+++ b/optimalportfolios/tests/local_path_test.py
@@ -1,12 +1,22 @@
 """
 the settings.yaml path accessors.
 
-Three lines of code with one property worth pinning: ``get_paths`` is ``lru_cache``d, so the
-YAML is read once per process and every later caller gets the first read back. That is the
-documented behaviour -- the docstring points at ``cache_clear`` -- but it also means a test
-that monkeypatches the settings file has to clear the cache on both sides or it leaks a fake
-path into every test that runs after it. The fixture below does exactly that, and the caching
-itself is asserted rather than assumed.
+``get_paths`` is ``lru_cache``d, so the YAML is read once per process and every later caller
+gets the first read back. That is documented -- the docstring points at ``cache_clear`` -- but
+it also means a test that monkeypatches the settings file must clear the cache on both sides or
+it leaks a fake path into every test that runs afterwards. The autouse fixture below does
+exactly that, and the caching itself is asserted rather than assumed.
+
+The resolution rules matter more than they look. A path may be absent, empty, the shipped ``..``
+placeholder, relative, or absolute, and each resolves differently: the first three fall back to
+checkout-aware defaults, a relative path is anchored to ``settings.yaml``'s own directory rather
+than the working directory, and only an absolute path is taken as given. Anchoring a relative
+path to the CWD instead would still produce a plausible directory -- one that moves depending on
+where the process was started.
+
+Every returned path is normalised to forward slashes, so a Windows-authored settings file and a
+POSIX one agree. That is asserted directly, since a backslash surviving into a path is exactly
+the defect this module was rewritten to fix (issue #43).
 """
 # packages
 import os
@@ -101,3 +111,98 @@ def test_absent_settings_file_uses_portable_checkout_defaults(tmp_path: Path, mo
     assert local_path.get_output_path() == expected_output.as_posix()
     assert chr(92) not in local_path.get_resource_path()
     assert chr(92) not in local_path.get_output_path()
+
+
+# --------------------------------------------------------------------------- #
+# how a configured value is resolved
+# --------------------------------------------------------------------------- #
+def test_a_relative_path_is_anchored_to_the_settings_file_not_the_working_directory(
+        tmp_path: Path, monkeypatch) -> None:
+    """A relative RESOURCE_PATH resolves against ``settings.yaml``'s own directory.
+
+    Anchoring to the CWD instead would still yield a plausible directory, but one that moves
+    with wherever the process happened to be started from.
+    """
+    settings_dir = tmp_path / 'config'
+    settings_dir.mkdir()
+    path = settings_dir / 'settings.yaml'
+    path.write_text(yaml.safe_dump({'RESOURCE_PATH': 'data', 'OUTPUT_PATH': 'out'}))
+    monkeypatch.setattr(local_path, '_SETTINGS_PATH', path)
+    monkeypatch.chdir(tmp_path)                       # a CWD that is *not* the settings dir
+
+    assert local_path.get_resource_path() == (settings_dir / 'data').resolve().as_posix()
+    assert local_path.get_output_path() == (settings_dir / 'out').resolve().as_posix()
+
+
+def test_an_absolute_path_is_taken_as_given(tmp_path: Path, monkeypatch) -> None:
+    """An absolute value is used unchanged, only normalised to forward slashes."""
+    target = tmp_path / 'absolute-resources'
+    path = tmp_path / 'settings.yaml'
+    path.write_text(yaml.safe_dump({'RESOURCE_PATH': str(target),
+                                    'OUTPUT_PATH': str(target)}))
+    monkeypatch.setattr(local_path, '_SETTINGS_PATH', path)
+
+    assert local_path.get_resource_path() == target.resolve().as_posix()
+    assert chr(92) not in local_path.get_resource_path()
+
+
+def test_a_user_home_prefix_is_expanded(tmp_path: Path, monkeypatch) -> None:
+    """``~`` is expanded rather than treated as a literal directory name."""
+    path = tmp_path / 'settings.yaml'
+    path.write_text(yaml.safe_dump({'RESOURCE_PATH': '~/resources',
+                                    'OUTPUT_PATH': '~/outputs'}))
+    monkeypatch.setattr(local_path, '_SETTINGS_PATH', path)
+
+    resolved = local_path.get_resource_path()
+    assert resolved == (Path.home() / 'resources').resolve().as_posix()
+    assert '~' not in resolved
+
+
+# --------------------------------------------------------------------------- #
+# malformed and empty settings files
+# --------------------------------------------------------------------------- #
+def test_an_empty_yaml_file_parses_to_no_settings_and_then_raises(tmp_path: Path,
+                                                                  monkeypatch) -> None:
+    """``yaml.safe_load`` gives None for an empty file, which ``get_paths`` maps to ``{}``.
+
+    An *absent* file falls back to the checkout defaults, but a file that exists and defines no
+    keys does not: it takes the same path as any file missing the key and raises ``KeyError``.
+    Worth stating explicitly, because "missing file" and "empty file" read as the same situation
+    and resolve differently -- the fallback is keyed on the file's existence, not its contents.
+    """
+    path = tmp_path / 'settings.yaml'
+    path.write_text('')
+    monkeypatch.setattr(local_path, '_SETTINGS_PATH', path)
+
+    assert local_path.get_paths() == {}
+    with pytest.raises(KeyError, match='RESOURCE_PATH'):
+        local_path.get_resource_path()
+
+
+def test_a_yaml_file_that_is_not_a_mapping_raises(tmp_path: Path, monkeypatch) -> None:
+    """A list or scalar document would fail later with a confusing index error."""
+    path = tmp_path / 'settings.yaml'
+    path.write_text(yaml.safe_dump(['RESOURCE_PATH', 'OUTPUT_PATH']))
+    monkeypatch.setattr(local_path, '_SETTINGS_PATH', path)
+
+    with pytest.raises(TypeError, match='must contain a mapping'):
+        local_path.get_paths()
+
+
+def test_an_unwritable_default_output_directory_raises(tmp_path: Path, monkeypatch) -> None:
+    """When no candidate directory can be created, the failure is explicit.
+
+    ``mkdir`` raising OSError on every candidate is the only way to exhaust the list, so it is
+    forced here; silently returning an unwritable path would fail later at the first save.
+    """
+    path = tmp_path / 'settings.yaml'
+    path.write_text(yaml.safe_dump({'RESOURCE_PATH': None, 'OUTPUT_PATH': None}))
+    monkeypatch.setattr(local_path, '_SETTINGS_PATH', path)
+
+    def refuse(self, *args, **kwargs):
+        """Stand in for a filesystem that refuses every directory creation."""
+        raise OSError('read-only filesystem')
+
+    monkeypatch.setattr(Path, 'mkdir', refuse)
+    with pytest.raises(OSError, match='no writable default output directory'):
+        local_path.get_output_path()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,4 +193,4 @@ omit = ["*/tests/*", "*/examples/*", "papers/*", "*/reports/*"]
 # Measure on a `[dev]` install, which is what the 3.12 leg of the `test` job in ci.yml does.
 # NetworkX remains a development dependency solely for independent matcher cross-checks; the
 # production `mcf` matcher and its regression tests run in a core install.
-fail_under = 95
+fail_under = 98

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,4 +193,4 @@ omit = ["*/tests/*", "*/examples/*", "papers/*", "*/reports/*"]
 # Measure on a `[dev]` install, which is what the 3.12 leg of the `test` job in ci.yml does.
 # NetworkX remains a development dependency solely for independent matcher cross-checks; the
 # production `mcf` matcher and its regression tests run in a core install.
-fail_under = 98
+fail_under = 99


### PR DESCRIPTION
Follow-on to #44, which narrowed the measured scope. This closes the largest remaining gaps and raises `fail_under` to 99.

Rebased onto current `main` (`125af26`). Statements are identical on both sides of the table below — this branch adds tests and changes no production code; the only non-test edits are `fail_under`, `CHANGELOG.md` and `AGENTS.md`.

| | Tests | Statements | Missed | Coverage |
|---|---:|---:|---:|---:|
| `main` (`125af26`) | 1156 | 5386 | 206 | 96.18% |
| **This branch** | **1276** | **5386** | **52** | **99.03%** |

154 missed lines closed across 11 modules, all measured on a `[dev]` install at the rebased head.

## Modules covered

| Module | Before | After |
|---|---:|---:|
| `alphas/backtest_alphas.py` | 42% | 100% |
| `optimization/general/max_sharpe.py` | 77% | 100% |
| `optimization/general/minimum_tracking_error.py` | 82% | 100% |
| `optimization/taa/maximise_alpha_with_target_yield.py` | 84% | 97% |
| `optimization/general/risk_budgeting_solver.py` | 93% | 99% |
| `alphas/signals/residual_reversal.py` | 88% | 100% |
| `alphas/signals/residual_momentum.py` | 90% | 100% |
| `alphas/signals/low_beta.py` | 90% | 100% |
| `local_path.py` | 89% | 100% |
| `alphas/signals/carry.py` | 94% | 100% |
| `alphas/signals/momentum.py` | 97% | 100% |

The four signal modules move together because they share one mixed-cadence-with-groups path, covered once in `mixed_cadence_grouping_test.py`.

## What the tests actually pin

These modules share a trait: their failure mode is a *plausible* wrong answer, not an exception. The tests are built around that rather than around line reachability.

- **`backtest_alphas.py`** — the three factsheet builders. The sweep test asserts the recorded target **weights** differ per leg, not the leg labels: those labels are formatted from the sweep values (`flong_span={span:0.0f}`), so they would read correctly even if the span never reached `compute_signal_scores` and every leg held an identical portfolio.

- **`max_sharpe.py`** — both solver paths, asserting **which solver ran**. Maximising Sharpe is not convex as written; the dispatcher routes to the Charnes-Cooper transform when `min_exposure == max_exposure` (an equality sum constraint to normalise against) and to SciPy SLSQP otherwise. Both return the same outcome type and both produce reasonable weights, so a mis-routed problem is indistinguishable from a solved one unless you check `outcome.solver`. The transform's unscaling (`w = z[:n] / z[n]`) is checked against the target exposure, and the recovered portfolio is scored against equal-weight and every single-asset portfolio — optimality is the claim the transform makes, and box-and-exposure assertions cannot see it.

- **`minimum_tracking_error.py`** — validation across all three entry points, which own different things: the rolling layer owns benchmark shape over time (Series broadcast vs DataFrame ffill), the wrapper owns covariance well-formedness after NaN filtering, and the CVXPY layer re-checks the raw array because it is public and callable without either wrapper. `(w - w_b)' Σ (w - w_b)` is well-defined for a benchmark that is misaligned, truncated, or NaN-filled-as-zero — CVXPY returns weights, `validate_solution` accepts them, and the portfolio tracks something nobody asked for. Includes the `SolverError` fallback, which must degrade to a rejected outcome rather than abort a rolling backtest at one bad date.

- **`maximise_alpha_with_target_yield.py`** — the yield floor, the absolute-vs-active objective switch, and the soft-TE branch. See the note below on how these were rewritten against `523466a`.

- **`risk_budgeting_solver.py`** — input validation and the box-infeasibility guards, where a budget that cannot be met inside the weight bounds must be rejected rather than silently approximated.

- **`residual_reversal.py`** — the four dispatch branches (string vs Series `returns_freq`, crossed with grouped vs ungrouped scoring), plus the raw signal asserted as the **exact negation** of `compute_residual_momentum_alpha`. That negation is the only thing distinguishing the module from its neighbour; drop it and the signal still scores, still backtests, and buys momentum winners under a module named reversal.

## Interaction with the #49 fix

This branch predates `523466a` and originally *pinned the bug*: a test asserted that `soft_tracking_error=True` with a populated `tracking_err_vol_constraint` solves `optimal` and is then rejected, plus a `### Known issues` changelog entry documenting it as caller-error. Both are gone.

`523466a` added its own `optimization/tests/maximise_alpha_with_target_yield_test.py`, which collided with this branch's file of the same name. The resolution keeps this branch's (broader) file and folds in every assertion from the three tests added by the fix, so nothing that landed with `523466a` is lost:

- a populated hard budget under `soft_tracking_error=True` is now asserted **accepted**, `assert_allclose`-equal to the utility-only solve, with `outcome.constraints.tracking_err_vol_constraint is None` and a realised tracking error exceeding the budget — so the case is one the budget would genuinely have rejected, not one where it happened not to bind;
- the paired hard-path test asserts the *same* constraints still fall back to benchmark weights with the flag off, which is what shows the fix loosened the soft branch rather than the budget everywhere;
- the turnover test additionally checks the recorded residual is present and `hard`, where a turnover term demoted to a penalty would show up.

The changelog entries for this branch now sit under `[Unreleased]`, above the `### Fixed` entry from `523466a`, which is preserved verbatim. The released `6.17.0` section is untouched.

## Review comments

Both Copilot comments on the previous head are addressed, in both cases by strengthening the assertion rather than renaming the test:

- **`max_sharpe_paths_test.py`** — the flagged test asserted only long-only bounds. The name was also wrong on its own terms: the best reward-to-risk asset in the fixture is B (0.417), not A, and the Sharpe optimum is ordered D > C > B > A, the exact inverse of the means, because the low-mean assets are the low-vol ones. It now asserts real optimality — the solution's Sharpe (0.659) beats equal-weight (0.607) and every single-asset portfolio (best 0.417) — and the docstring records why no weights-vs-means ordering is asserted.

- **`residual_reversal_test.py`** — the flagged test compared score ranks against this module's own raw frame, which holds whether or not the negation happened and proves only that the scorer is order-preserving. It now anchors the extremes on `compute_residual_momentum_alpha`: the worst residual momentum must carry the top reversal score. This required passing spans explicitly — the two entry points default to `long_span=1` and `12` respectively, so the implicit-default comparison was between two different signals.

## Checks

Measured at `a7eb4e1`:

- `pytest` — **1276 passed**, 0 failed, 0 xfailed (~160 s)
- `pytest --cov=optimalportfolios` — 99.03%, floor 99
- `ruff check --select TID251,TID253,ICN,F optimalportfolios/` — clean
- `interrogate` — 100%
- CI — all 18 jobs green

Worth recording: at 52 missed of 5386, `fail_under = 99` leaves **1 line of headroom**, tighter than the ~17 the floor of 98 allowed. The gate runs only on the ubuntu/3.12 cell rather than across the matrix, so platform variance does not eat into that, but the next PR adding a lightly-covered branch will meet the floor rather than review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
