### PR TITLE
JOSS dry-run remediation: POSIX paths, API reference pages, version metadata (from #43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,10 @@ jobs:
         print('factorlasso integration OK')
         "
 
+    - name: Smoke-test the offline multi-asset example
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+      run: python optimalportfolios/examples/backtests/multiasset_saa.py
+
     - name: Run the test suite with coverage gate
       # The floor lives in [tool.coverage.report] fail_under in pyproject.toml, so this job
       # fails when coverage regresses below it. term-missing prints the uncovered lines, which

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Every file matching pytest's default patterns — `*_test.py` **and** `test_*.py
 
 ```bash
 pip install -e ".[dev]"                                  # editable install with dev tools
-pytest                                                   # run the test suite (1145 tests, ~60 s)
+pytest                                                   # run the test suite (1149 tests, ~2 min)
 pytest optimalportfolios/optimization/tests/constraints_test.py -v
 ruff check optimalportfolios/                            # lint (papers/ is excluded)
 interrogate                                              # docstring coverage, must stay at 100%
@@ -76,7 +76,7 @@ interrogate                                              # docstring coverage, m
 
 Optional extras: `data`, `reports`, `jupyter`, `dev`, `all`. Supported Python is >= 3.10; CI runs 3.10 – 3.13 on a `[dev]` install and 3.12 again on a core install, which must be green: no test may need data, network or a Bloomberg terminal. Both of those jobs run on `ubuntu-latest`, `windows-latest` and `macos-latest`, so a fix that only holds on POSIX paths or POSIX line endings fails the matrix. The ubuntu/Python 3.12 coverage cell alone installs against `constraints.txt`, regenerated at each release; the remaining matrix cells, core installs and audit resolution deliberately float. Separate jobs gate the three ruff stack invariants, `interrogate` docstring coverage at 100%, and `pip-audit` over the dependency tree resolved from `pyproject.toml`. Run `interrogate` from the repository root — the `papers/` exclusion in `[tool.interrogate]` is resolved against the working directory.
 
-Line coverage measured **96.18%** on the 1145-test dev suite. The
+Line coverage measured **96.10%** on the 1149-test dev suite. The
 ubuntu/3.12 matrix entry gates `pytest --cov=optimalportfolios` at `fail_under = 95`; this floor rises
 whenever measured coverage rises, and lowering it requires a dated `CHANGELOG.md` note.
 The measured scope is not the whole package: `[tool.coverage.run] omit` drops `reports/` alongside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ from `fail_under = 88` to `95`: measured coverage over the narrowed scope is 96.
 
 ### Added
 
+- Exposed `optimalportfolios.__version__` from installed distribution metadata and added
+  per-object Sphinx API pages with full signatures and rendered argument documentation.
 - Tests for five previously unexercised modules: the rank-based alpha profiler
   (`alphas/profile/core.py`, `alphas/profile/signal_profilers.py`), the alpha container
   (`alphas/alpha_data.py`), the HCGL covariance report (`covar_estimation/covar_reporting.py`),
@@ -25,9 +27,19 @@ from `fail_under = 88` to `95`: measured coverage over the narrowed scope is 96.
 
 ### Fixed
 
+- Made resource and output paths platform-neutral with `pathlib`; a missing or placeholder
+  `settings.yaml` now selects a writable checkout-aware default instead of a literal Windows
+  separator, and the offline multi-asset example now imports its shipped fixture. The defect
+  was reported by @tschm in issue #43.
 - Reconstructed factorlasso's flat, persisted cluster/linkage/cutoff fields by cadence before
   plotting, so `plot_current_covar_data` and `run_rolling_covar_report(is_plot=True)` render
   multi-asset universes again. The defect was discovered by @tschm in PR #44.
+
+### Changed
+
+- Clarified the public reproduction boundary and recorded known environment versions for every
+  paper folder in `papers/README.md`; the package classifier now matches the documented
+  Production/Stable maturity.
 
 ## [6.16.0] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ from optimalportfolios import (
     PortfolioObjective,
     compute_rolling_optimal_weights,
 )
-from optimalportfolios.examples.data.multiasset import load_multiasset_data
+from optimalportfolios.tests.data.multiasset import load_multiasset_data
 
 prices = load_multiasset_data().prices.iloc[-120:, :4]
 time_period = qis.TimePeriod(prices.index[0], prices.index[-1])

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,5 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,7 @@ root. ``autosummary`` provides a compact inventory; ``autodoc`` provides the
 signatures and docstrings.
 
 .. autosummary::
+   :toctree: generated
 
    optimalportfolios.AlphasData
    optimalportfolios.ConstraintEnforcementType

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,8 @@ autosummary_generate = True
 autosummary_imported_members = True
 autodoc_typehints = "description"
 napoleon_google_docstring = True
-napoleon_numpy_docstring = False
+napoleon_numpy_docstring = True
+napoleon_use_param = False
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,7 +16,7 @@ rebalancing cost.
        PortfolioObjective,
        compute_rolling_optimal_weights,
    )
-   from optimalportfolios.examples.data.multiasset import load_multiasset_data
+   from optimalportfolios.tests.data.multiasset import load_multiasset_data
 
    prices = load_multiasset_data().prices.iloc[-120:, :4]
    time_period = qis.TimePeriod(prices.index[0], prices.index[-1])

--- a/optimalportfolios/__init__.py
+++ b/optimalportfolios/__init__.py
@@ -2,9 +2,17 @@
 and the alpha and reporting layers, re-exported from their subpackages.
 """
 
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _distribution_version
+
 import optimalportfolios.local_path
 
 from optimalportfolios.config import PortfolioObjective
+
+try:
+    __version__ = _distribution_version('optimalportfolios')
+except _PackageNotFoundError:  # pragma: no cover - only an uninstalled source tree reaches this
+    __version__ = '0+unknown'
 
 # Each star below re-exports its subpackage's namespace, so a subpackage's public surface is
 # the imports written in its own ``__init__`` and nothing beside them. F401 and F403 are off

--- a/optimalportfolios/alphas/profile/core.py
+++ b/optimalportfolios/alphas/profile/core.py
@@ -95,8 +95,8 @@ def backtest_alpha_rank_portfolio(prices: pd.DataFrame,
         benchmark_ticker: name for the equal-weight benchmark leg.
 
     Returns:
-        qis.MultiPortfolioData: [*alpha legs, equal-weight benchmark]. The benchmark is always
-        last, so portfolio_datas[-1] is the equal-weight reference.
+        qis.MultiPortfolioData: The alpha legs followed by the equal-weight benchmark. The
+        benchmark is always last, so ``portfolio_datas[-1]`` is the equal-weight reference.
     """
     # normalise to a label -> score-panel dict so single-panel and multi-panel share one code path
     if isinstance(alpha_scores, pd.DataFrame):

--- a/optimalportfolios/covar_estimation/factor_covar_estimator.py
+++ b/optimalportfolios/covar_estimation/factor_covar_estimator.py
@@ -422,21 +422,15 @@ def estimate_lasso_factor_covar_data(risk_factor_prices: pd.DataFrame,
     then assembles the factor covariance matrix, betas, idiosyncratic variances,
     and in-sample diagnostics into CurrentFactorCovarData.
 
-    Convention:
-        estimated_betas from LassoModel is (N x M) with index=assets, columns=factors.
-        y_betas in CurrentFactorCovarData follows the same (N x M) convention.
+    ``LassoModel.estimated_betas`` and ``CurrentFactorCovarData.y_betas`` both use the
+    (N x M) convention with assets on rows and factors on columns. Clusters, linkages and
+    cutoffs are fitted per frequency, then flattened into persistable pandas objects:
 
-        Clusters, linkages and cutoffs are fitted per-frequency (one clustering
-        step per freq block of assets) but flattened into persistable pandas
-        objects before construction:
-          - clusters: pd.Series indexed by asset (each asset appears in
-            exactly one freq bucket), values are freq-prefixed cluster IDs.
-          - linkages: pd.DataFrame of scipy linkage rows, stacked across
-            freqs with a freq-prefixed merge-step index, columns
-            ['left', 'right', 'distance', 'n_samples']. Use
-            ``factor_covar.get_linkage_array(linkages, freq)`` to recover
-            a scipy-compatible ndarray for a given frequency.
-          - cutoffs: pd.Series indexed by freq code.
+    - ``clusters`` is a Series indexed by asset with frequency-prefixed cluster IDs.
+    - ``linkages`` stacks scipy linkage rows across frequencies under a frequency-prefixed
+      merge-step index. ``factor_covar.get_linkage_array(linkages, freq)`` recovers one
+      scipy-compatible array.
+    - ``cutoffs`` is a Series indexed by frequency code.
 
     Args:
         risk_factor_prices: Factor price series. Index=dates, columns=factor names.

--- a/optimalportfolios/examples/backtests/multiasset_saa.py
+++ b/optimalportfolios/examples/backtests/multiasset_saa.py
@@ -18,7 +18,7 @@ from optimalportfolios import (Constraints, GroupLowerUpperConstraints, EwmaCova
                                PortfolioObjective,
                                compute_rolling_optimal_weights,
                                backtest_rolling_optimal_portfolio)
-from optimalportfolios.examples.data.multiasset import load_multiasset_data
+from optimalportfolios.tests.data.multiasset import load_multiasset_data
 
 # annual SAA cadence: 3y EWMA on monthly returns, rebalanced year-end
 RETURNS_FREQ = 'ME'

--- a/optimalportfolios/local_path.py
+++ b/optimalportfolios/local_path.py
@@ -1,46 +1,94 @@
+"""Resolve configured resource and output directories portably.
+
+``settings.yaml`` may override either directory with an absolute or relative path.  A missing
+file, an empty value, or the shipped parent-directory placeholder uses checkout-aware defaults:
+the repository root for resources and ``<repository>/outputs`` for generated files.  Installed
+packages fall back to the current working directory because no checkout root is available.
 """
-local_path uses setting.yaml to return absolute path for file/folder paths
-use:
-git update-index --skip-worktree settings.yaml
 
-example usage:
-import local_path as lp
-lp.get_resource_path()
-
-for linux use
 import os
-import sys
-sys.path.append(os.getcwd())
-"""
-
-import yaml
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict
 
-_SETTINGS_PATH = Path(__file__).parent.joinpath('settings.yaml')
+import yaml
+
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_SETTINGS_PATH = _PACKAGE_DIR / 'settings.yaml'
+
+
+def _checkout_root() -> Path | None:
+    """Return the repository root when this module is running from a checkout."""
+    candidate = _PACKAGE_DIR.parent
+    return candidate if (candidate / 'pyproject.toml').is_file() else None
+
+
+def _as_portable_string(path: Path) -> str:
+    """Return an absolute path with forward separators on every platform."""
+    return path.expanduser().resolve().as_posix()
+
+
+def _is_placeholder(value: object) -> bool:
+    """Return whether a YAML value is empty or the shipped parent-directory placeholder."""
+    if value is None:
+        return True
+    normalized = str(value).strip().replace(chr(92), '/').rstrip('/')
+    return normalized in {'', '..'}
+
+
+def _default_resource_path() -> Path:
+    """Return the checkout root, or the working directory for an installed package."""
+    return _checkout_root() or Path.cwd()
+
+
+def _default_output_path() -> Path:
+    """Create and return the first writable default output directory."""
+    checkout_root = _checkout_root()
+    candidates = [checkout_root / 'outputs', Path.cwd()] if checkout_root else [Path.cwd()]
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            continue
+        if candidate.is_dir() and os.access(candidate, os.W_OK):
+            return candidate
+    raise OSError('no writable default output directory is available')
 
 
 @lru_cache(maxsize=1)
-def get_paths() -> Dict[str, str]:
-    """
-    read path specs in settings.yaml; cached after first call.
-    Call get_paths.cache_clear() to force a re-read.
-    """
-    with open(_SETTINGS_PATH) as settings:
+def get_paths() -> Dict[str, object]:
+    """Read the path settings once; call ``cache_clear`` to force a re-read."""
+    if not _SETTINGS_PATH.is_file():
+        return {}
+    with _SETTINGS_PATH.open(encoding='utf-8') as settings:
         settings_data = yaml.safe_load(settings)
+    if settings_data is None:
+        return {}
+    if not isinstance(settings_data, dict):
+        raise TypeError('settings.yaml must contain a mapping')
     return settings_data
 
 
+def _configured_path(key: str, default_factory) -> str:
+    """Resolve one configured path, preserving missing-key errors in an existing file."""
+    paths = get_paths()
+    if not _SETTINGS_PATH.is_file():
+        return _as_portable_string(default_factory())
+    value = paths[key]
+    if _is_placeholder(value):
+        return _as_portable_string(default_factory())
+    path = Path(str(value)).expanduser()
+    if not path.is_absolute():
+        path = _SETTINGS_PATH.parent / path
+    return _as_portable_string(path)
+
+
 def get_resource_path() -> str:
-    """
-    resource path from settings.yaml
-    """
-    return get_paths()['RESOURCE_PATH']
+    """Return the configured resource directory or its checkout-aware default."""
+    return _configured_path('RESOURCE_PATH', _default_resource_path)
 
 
 def get_output_path() -> str:
-    """
-    output path from settings.yaml
-    """
-    return get_paths()['OUTPUT_PATH']
+    """Return the configured output directory or a writable checkout-aware default."""
+    return _configured_path('OUTPUT_PATH', _default_output_path)

--- a/optimalportfolios/optimization/portfolio_result.py
+++ b/optimalportfolios/optimization/portfolio_result.py
@@ -38,30 +38,16 @@ def _to_dataframe(w: Union[pd.Series, pd.DataFrame], default_name: str = 'portfo
 
 @dataclass
 class PortfolioOptimisationResult:
-    """
-    Portfolio optimisation output with factor model context for risk attribution.
+    """Portfolio optimisation output with factor model context for risk attribution.
 
     Tracking-error and factor-exposure computations delegate to ``qis.RiskModel`` in
     ``qis.portfolio.risk.risk_model``.
 
-    Supports N portfolios via DataFrame inputs. When weights is a DataFrame,
-    each column is a separate portfolio. benchmark_weights is matched:
-      - Series: same benchmark for all portfolios
-      - DataFrame: per-portfolio benchmarks (columns must match weights columns)
-
-    current_weights is optional (needed only for turnover analysis):
-      - Series: same current weights for all portfolios
-      - DataFrame: per-portfolio current weights (columns must match weights columns)
-
-    Risk decomposition:
-        sigma^2_p = w' Sigma_y w = w' beta Sigma_x beta' w + w' D w
-                  = systematic risk  + idiosyncratic risk
-
-    Active risk (tracking error):
-        TE^2 = delta' Sigma_y delta  where delta = w - w_bench
-
-    Turnover:
-        turnover = sum |w_new - w_current| / 2
+    ``weights`` and ``benchmark_weights`` may be a Series for one portfolio or DataFrames whose
+    columns are portfolios. ``current_weights`` follows the same convention when turnover is
+    requested. Risk is decomposed into systematic and idiosyncratic terms; active risk applies
+    the same covariance model to benchmark-relative weights, and one-way turnover is half the
+    L1 distance between new and current weights.
     """
 
     # Core portfolio weights: Series (single) or DataFrame (N portfolios as columns)

--- a/optimalportfolios/optimization/taa/maximise_alpha_with_target_yield.py
+++ b/optimalportfolios/optimization/taa/maximise_alpha_with_target_yield.py
@@ -251,15 +251,15 @@ def cvx_maximise_alpha_with_target_return(covar: np.ndarray,
 
     Two formulations, selected by ``soft_tracking_error``:
 
-    Hard tracking error (default, soft_tracking_error=False):
+    Hard tracking error (default, ``soft_tracking_error=False``)::
 
         max_w  α'(w - w_b)
         s.t.   y'w >= r_target                      (hard return target)
                (w - w_b)'Σ(w - w_b) <= TE²_max      (hard TE, if set on constraints)
                1'w = 1,  w >= 0,  bounds
 
-    Soft tracking error (soft_tracking_error=True) — TE drops from a hard
-    constraint to a penalty so the return target always takes priority:
+    Soft tracking error (``soft_tracking_error=True``) drops TE from a hard
+    constraint to a penalty so the return target always takes priority::
 
         max_w  α'(w - w_b) - λ_TE (w - w_b)'Σ(w - w_b) - λ_TO ||w - w_0||_1
         s.t.   y'w >= r_target                      (hard return target)

--- a/optimalportfolios/reports/portfolio_result_plots.py
+++ b/optimalportfolios/reports/portfolio_result_plots.py
@@ -38,9 +38,8 @@ def plot_efficient_frontier(
 
     Args:
         result: PortfolioOptimisationResult instance with N portfolios.
-        profiles: Dict mapping profile name to list of portfolio names.
-                  Example: {'w/o Alts': ['Income w/o Alts', 'Low w/o Alts', ...],
-                            'with Alts': ['Income with Alts', 'Low with Alts', ...]}
+        profiles: Mapping from profile name to portfolio names, for example
+            ``{'w/o Alts': ['Income w/o Alts'], 'with Alts': ['Income with Alts']}``.
         order: Polynomial order for scatter fit curve.
         markersize: Marker size for scatter points.
         xvar_format: Format string for x-axis (volatility).

--- a/optimalportfolios/settings.yaml
+++ b/optimalportfolios/settings.yaml
@@ -1,19 +1,13 @@
-# set pc/developer local paths
-# add to gitignore afterwards
-# set paths to dbs
-
+# Optional developer-local paths. Null values select portable checkout-aware defaults.
+# Replace a value with an absolute or relative path only when a local override is needed.
 
 RESOURCE_PATH:
-  "..\\"
 
 LOCAL_RESOURCE_PATH:
-  "..\\"
 
 UNIVERSE_PATH:
-  "..\\"
 
 OUTPUT_PATH:
-  "..\\"
 
 AWS_POSTGRES:
   ""

--- a/optimalportfolios/tests/local_path_test.py
+++ b/optimalportfolios/tests/local_path_test.py
@@ -9,6 +9,7 @@ path into every test that runs after it. The fixture below does exactly that, an
 itself is asserted rather than assumed.
 """
 # packages
+import os
 from pathlib import Path
 import pytest
 import yaml
@@ -28,7 +29,10 @@ def clear_path_cache():
 def settings_file(tmp_path: Path, monkeypatch) -> Path:
     """Point the module at a temporary settings.yaml with both documented keys."""
     path = tmp_path / 'settings.yaml'
-    path.write_text(yaml.safe_dump({'RESOURCE_PATH': '/resources/', 'OUTPUT_PATH': '/outputs/'}))
+    resource_path = tmp_path / 'resources'
+    output_path = tmp_path / 'outputs'
+    path.write_text(yaml.safe_dump({'RESOURCE_PATH': str(resource_path),
+                                    'OUTPUT_PATH': str(output_path)}))
     monkeypatch.setattr(local_path, '_SETTINGS_PATH', path)
     return path
 
@@ -41,18 +45,21 @@ def test_the_shipped_settings_file_carries_both_keys() -> None:
 
 def test_the_resource_and_output_paths_are_read_from_the_yaml(settings_file: Path) -> None:
     """Both accessors are thin lookups into the parsed settings."""
-    assert local_path.get_resource_path() == '/resources/'
-    assert local_path.get_output_path() == '/outputs/'
+    paths = yaml.safe_load(settings_file.read_text())
+    assert local_path.get_resource_path() == Path(paths['RESOURCE_PATH']).as_posix()
+    assert local_path.get_output_path() == Path(paths['OUTPUT_PATH']).as_posix()
 
 
 def test_the_settings_are_read_once_and_then_cached(settings_file: Path) -> None:
     """A later edit to the file is not picked up until the cache is cleared."""
-    assert local_path.get_resource_path() == '/resources/'
-    settings_file.write_text(yaml.safe_dump({'RESOURCE_PATH': '/changed/',
-                                             'OUTPUT_PATH': '/outputs/'}))
-    assert local_path.get_resource_path() == '/resources/'      # still the cached read
+    initial = Path(yaml.safe_load(settings_file.read_text())['RESOURCE_PATH']).as_posix()
+    changed = settings_file.parent / 'changed'
+    assert local_path.get_resource_path() == initial
+    settings_file.write_text(yaml.safe_dump({'RESOURCE_PATH': str(changed),
+                                             'OUTPUT_PATH': str(settings_file.parent / 'outputs')}))
+    assert local_path.get_resource_path() == initial      # still the cached read
     local_path.get_paths.cache_clear()
-    assert local_path.get_resource_path() == '/changed/'
+    assert local_path.get_resource_path() == changed.as_posix()
 
 
 def test_a_missing_key_raises_rather_than_returning_none(tmp_path: Path, monkeypatch) -> None:
@@ -62,3 +69,31 @@ def test_a_missing_key_raises_rather_than_returning_none(tmp_path: Path, monkeyp
     monkeypatch.setattr(local_path, '_SETTINGS_PATH', path)
     with pytest.raises(KeyError, match='OUTPUT_PATH'):
         local_path.get_output_path()
+
+
+@pytest.mark.parametrize('settings_value', [None, '..'])
+def test_placeholder_output_falls_back_to_a_writable_checkout_directory(
+        settings_value, tmp_path: Path, monkeypatch) -> None:
+    """An empty or shipped placeholder output resolves to the writable checkout output dir."""
+    path = tmp_path / 'settings.yaml'
+    path.write_text(yaml.safe_dump({'RESOURCE_PATH': settings_value,
+                                    'OUTPUT_PATH': settings_value}))
+    monkeypatch.setattr(local_path, '_SETTINGS_PATH', path)
+
+    output_path = Path(local_path.get_output_path())
+
+    assert output_path == Path(__file__).resolve().parents[2] / 'outputs'
+    assert output_path.is_dir()
+    assert os.access(output_path, os.W_OK)
+    assert chr(92) not in local_path.get_output_path()
+
+
+def test_absent_settings_file_uses_portable_checkout_defaults(tmp_path: Path, monkeypatch) -> None:
+    """A missing YAML file uses the checkout root and its writable output directory."""
+    monkeypatch.setattr(local_path, '_SETTINGS_PATH', tmp_path / 'absent.yaml')
+
+    assert local_path.get_resource_path() == Path(__file__).resolve().parents[2].as_posix()
+    assert local_path.get_output_path() == (
+        Path(__file__).resolve().parents[2] / 'outputs').as_posix()
+    assert chr(92) not in local_path.get_resource_path()
+    assert chr(92) not in local_path.get_output_path()

--- a/optimalportfolios/tests/version_metadata_test.py
+++ b/optimalportfolios/tests/version_metadata_test.py
@@ -18,6 +18,8 @@ from typing import Optional
 import pytest
 import yaml
 
+import optimalportfolios
+
 
 def _repo_root() -> Optional[Path]:
     """return the first ancestor holding pyproject.toml, or None."""
@@ -71,6 +73,11 @@ def test_citation_cff_matches_pyproject():
 def test_readme_bibtex_matches_pyproject():
     """The README BibTeX entry and ``pyproject.toml`` declare the same version."""
     assert _readme_bibtex_version() == _pyproject_version()
+
+
+def test_package_version_matches_pyproject():
+    """The importable package version agrees with the release metadata."""
+    assert optimalportfolios.__version__ == _pyproject_version()
 
 
 def test_citation_cff_date_released_is_iso():

--- a/papers/README.md
+++ b/papers/README.md
@@ -1,18 +1,26 @@
 # Paper Code
 
-This directory contains reproduction code for published research papers that use the `optimalportfolios` package. Each subdirectory corresponds to one paper and contains the complete pipeline that generates the published exhibits.
+This directory contains research code associated with papers that use `optimalportfolios`.
+The folders do not all provide the same level of reproduction: the table below states what a
+public checkout can run and records package versions only where the repository preserves them.
 
-Each subdirectory is **self-contained**: it ships its own `README.md` (with full methodology), reproduction scripts, and tests. Running the scripts in isolation reproduces the paper's headline numbers within Monte Carlo noise.
+## Index and public reproduction status
 
-## Index
+| Subdirectory | Paper | What a public checkout reproduces | Recorded package versions |
+|---|---|---|---|
+| [`crypto_allocation_risk_2023/`](crypto_allocation_risk_2023/) | Sepp (2023), *Optimal Allocation to Cryptocurrencies in Diversified Portfolios*, *Risk* | Historical CSV files are committed, but the scripts also use live `yfinance` data, one report imports the optional `pybloqs` backend, and no frozen environment is recorded. The repository therefore does not promise exact headline-number reproduction. | Not recorded |
+| [`robust_optimisation_jpm_2026/`](robust_optimisation_jpm_2026/) | Sepp, Ossa and Kastenholz (2026), *Robust Optimization of Strategic and Tactical Asset Allocation for Multi-Asset Portfolios*, *The Journal of Portfolio Management* 52(4), 86–120 | The folder demonstrates the published HCGL and risk-budgeting workflow, but downloads its ETF panel from `yfinance` and carries neither frozen inputs nor an environment pin. It is a methodological example, not an exact exhibit rebuild. | Not recorded |
+| [`matf_cma_jpm_2026/`](matf_cma_jpm_2026/) | Sepp, Hansen and Kastenholz (2026), *Capital Market Assumptions Using Multi-Asset Tradable Factors: The MATF-CMA Framework*, under review | The committed 2026-Q2 snapshot runs 8 of 12 replication scripts in full. Four scripts need licensed return panels that are not committed; the exact files and affected outputs are listed in the [replication README](matf_cma_jpm_2026/replication/README.md#what-runs-on-a-public-checkout). | Snapshot manifest: `optimalportfolios` 6.6.0, `qis` 5.0.5, `factorlasso` 0.10.1 |
 
-| Subdirectory | Paper | Citation |
-|---|---|---|
-| [`matf_cma_jpm_2026/`](matf_cma_jpm_2026/) | Capital Market Assumptions Using Multi-Asset Tradable Factors: The MATF-CMA Framework | Sepp, Hansen, Kastenholz (2026), *JPM*, under review (JPM-093244) |
+`cma_data/` is the shared, manifest-verified data layer used by the MATF-CMA replication; it is
+not a fourth paper. Its public snapshot includes the configuration tables that the public
+scripts need and deliberately omits licensed index, factor-history and provider panels.
 
 ## Conventions
 
-- A per-paper directory either tracks the current package code or states the `optimalportfolios` and `qis` versions it shipped with, in its own README. A directory is **frozen at the time of paper acceptance**, and the version statement is what makes the frozen result reproducible. No directory carries such a statement yet.
-- Reproduction scripts are designed to be run as standalone Python scripts from within their directory: `cd matf_cma_jpm_2026/replication && python run_bootstrap.py`.
-- Per-paper subdirectories are not Python packages and do not have `__init__.py`. They are not installed by `pip install optimalportfolios`.
-- Production input data files (proprietary CSV / xlsx pipeline outputs) are not committed to the repository. The methodology in each per-paper README is fully self-contained and reproducible against any equivalent pipeline.
+- Each paper folder documents its own run commands and data requirements. A missing input is a
+  declared limitation, not something to replace with synthetic or live data silently.
+- Paper folders are repository-only research artifacts and are not installed by
+  `pip install optimalportfolios`.
+- Frozen package versions are quoted from a committed manifest when one exists. The older
+  folders have no recorded environment, so no version is inferred after the fact.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ keywords = [
     "cvxpy",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Financial and Insurance Industry",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
## Summary

- make configured resource/output paths portable and provide writable checkout-aware fallbacks
- generate substantive Sphinx pages for all 125 public API names, including signatures and argument documentation
- expose optimalportfolios.__version__, align the maturity classifier, and correct paper-reproduction claims
- repair the offline multi-asset example's fixture import and smoke-test it on Ubuntu/Python 3.12

## Verification

- 1,149 tests pass with MPLBACKEND=Agg
- coverage 96.10% (95% floor)
- gated Ruff families pass
- interrogate reports 100.0%
- sphinx-build -W succeeds
- offline multi-asset example completes without network access

This implements the applicable repository findings reported by @tschm in #43. It deliberately does not close or answer that issue.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Improved cross-platform compatibility by migrating resource and output paths to pathlib.</li>
<li>Exposed package version metadata and enhanced Sphinx API documentation with full signatures and argument details.</li>
<li>Fixed a bug in the offline multi-asset example and updated its data import path.</li>
<li>Added a smoke test for the multi-asset example in the CI pipeline.</li>
<li>Updated documentation and CHANGELOG to reflect changes and clarify reproduction boundaries.</li>
</ul></div>