### PR TITLE
Declare least-privilege token scope in every workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,5 +1,14 @@
 name: Audit
 
+# Least privilege, declared rather than inherited; see the fuller note in ci.yml. This workflow
+# resolves dependency trees and runs pip-audit over them, and installs nothing -- it never touches
+# the token -- so `contents: read` covers the checkout and nothing else is needed.
+#
+# Worth stating for the scheduled trigger in particular: a daily run is the one that fires with no
+# one watching, so it should hold the narrowest scope of the four, not the ambient default.
+permissions:
+  contents: read
+
 # The audit's verdict is a function of two things -- the dependency floors in pyproject.toml and
 # the state of the advisory database -- and neither is the source tree. That cuts both ways, and
 # is why this is not a step in static.yml on the every-push trigger:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,20 @@
 name: CI
 
+# Least privilege, declared rather than inherited. Without this block every job runs with the
+# repository's *default* `GITHUB_TOKEN` scope, which on a repository configured for read-write
+# defaults is write access to contents, issues, packages and more -- handed to twelve matrix cells
+# that only check out a tree and run pytest.
+#
+# Nothing in this workflow uses the token: no `gh` call, no artifact upload, no PR comment, no push.
+# `contents: read` is what `actions/checkout` needs and is therefore the whole requirement. Declared
+# at workflow level so a new job inherits the restriction instead of the default.
+#
+# This matters most for `pull_request`, which is the trigger that runs contributor-authored changes
+# to workflow-adjacent files. Scope is the containment; add a permission to the one job that needs
+# it if that ever changes, never here.
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,5 +1,16 @@
 name: Examples
 
+# Least privilege, declared rather than inherited; see the fuller note in ci.yml. Both lanes check
+# out the tree, install, and run example scripts. The network lane additionally writes a report to
+# `$GITHUB_STEP_SUMMARY`, which is a file write on the runner and needs no permission -- so
+# `contents: read` covers this workflow too.
+#
+# This one has the strongest case of the four: the network lane executes example code that
+# downloads from Yahoo Finance, on a schedule, unattended. Whatever that code does, it should not do
+# it holding a writable repository token.
+permissions:
+  contents: read
+
 # `examples/` is the one part of the tree nothing else executes. It is excluded from wheels,
 # dropped by `[tool.coverage.run] omit`, and never collected by pytest, so an example can reference
 # an API that no longer exists and stay broken indefinitely. Ruff does not close the gap either:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,5 +1,15 @@
 name: Static
 
+# Least privilege, declared rather than inherited; see the fuller note in ci.yml. This job checks
+# out the tree and runs ruff and interrogate over it -- no token use of any kind -- so `contents:
+# read` is the entire requirement, and without this block it would instead inherit the repository's
+# default `GITHUB_TOKEN` scope.
+#
+# The every-push trigger below makes this the most frequently started workflow in the repository,
+# which is a reason to keep its token narrow rather than a reason to skip the declaration.
+permissions:
+  contents: read
+
 # Two triggers, both unconditional, and deliberately overlapping.
 #
 # `pull_request` is the gate: it is the event a required status check is resolved against, and it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ floor rises whenever measured coverage rises, and lowering it requires a dated n
 
 ### Changed
 
+- Declared `permissions: {contents: read}` in all four workflows. They previously carried no
+  `permissions:` block at all, so every job inherited the repository's default `GITHUB_TOKEN`
+  scope — up to write access on contents, issues and packages — across sixteen jobs that only check
+  out a tree and run a tool. No step in any workflow uses the token: there is no `gh` call, no
+  artifact upload, no PR comment and no push, and the network lane's report is a `$GITHUB_STEP_SUMMARY`
+  file write, which needs no permission. Declared at workflow level so a new job inherits the
+  restriction rather than the default.
 - Moved the repository-only worked examples from `optimalportfolios/examples/` to root-level
   `examples/`, making them visible beside the package while keeping them out of wheels and sdists.
   Example and local-diagnostic imports, documentation links, the workflow runner, and packaging,


### PR DESCRIPTION
## Why

None of the four workflows carried a `permissions:` block, so all sixteen jobs ran with the repository's **default** `GITHUB_TOKEN` scope. On a repository configured for read-write defaults that is write access to contents, issues, packages and more — handed to jobs whose entire work is checking out a tree and running pytest, ruff, pip-audit or an example script.

This came out of a comparison with the rhiza-managed workflows in `jebel-quant/jquantstats`, where every workflow declares least privilege explicitly.

## What

`permissions: {contents: read}` at workflow level in `ci.yml`, `static.yml`, `audit.yml` and `examples.yml`.

`contents: read` is what `actions/checkout` needs, and it is the whole requirement — no step in any of the four uses the token:

- no `gh` invocation, no `secrets.*` reference
- no artifact upload, no PR comment, no push, no release
- the network lane's report goes to `$GITHUB_STEP_SUMMARY`, which is a file write on the runner and needs no permission
- the only actions used are `actions/checkout` and `astral-sh/setup-uv`, both already SHA-pinned

Declared at workflow level rather than per job, so a job added later inherits the restriction instead of silently reverting to the default.

Two triggers make this worth doing rather than merely tidy:

- **`pull_request`** is the trigger that runs contributor-authored changes.
- **The daily schedules** in `audit.yml` and `examples.yml` fire unattended, and the examples network lane executes example code that downloads from Yahoo Finance. Whatever that code does, it should not do it holding a writable repository token.

## Verification

- All four files parse, and each reports `permissions={'contents': 'read'}` over its jobs (`test`; `static`; `audit`; `offline`, `network`).
- `grep -rn "secrets\.\|GITHUB_TOKEN\|gh api\|gh pr\|gh release" .github/workflows/` returns only the two occurrences inside the new explanatory comments — nothing functional.

Comments and no functional YAML beyond the four blocks; the checks on this PR exercise the change directly, since every job in it now runs under the narrowed scope.

Independent of #58 — this branches from `main`, and the two touch different regions of `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
