### PR TITLE
Prepare release 6.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [6.18.0] - 2026-08-14
+
 **Coverage floor raised (2026-08-13):** `fail_under` rises from `95` to `99`; measured coverage
 over the scope narrowed in 6.17.0 is 99.09%, on a suite grown from 1145 to 1277 tests. The
 floor rises whenever measured coverage rises, and lowering it requires a dated note here.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 repository-code: "https://github.com/ArturSepp/OptimalPortfolios"
 url: "https://pypi.org/project/optimalportfolios/"
 license: MIT
-version: 6.17.0
-date-released: "2026-08-12"
+version: 6.18.0
+date-released: "2026-08-14"
 keywords:
   - portfolio-optimization
   - backtesting

--- a/README.md
+++ b/README.md
@@ -946,12 +946,13 @@ Portfolios", *The Journal of Portfolio Management*, 52(4), 86-120.
 
 ## Updates
 
-#### August 2026, Versions 6.8.0–6.17.0 released
+#### August 2026, Versions 6.8.0–6.18.0 released
 
-The recent 6.x series through 6.17.0 added several production analytics that are now part of the current API:
+The recent 6.x series through 6.18.0 added several production analytics that are now part of the current API:
 
 | Release | Analytics and behavior added |
 | --- | --- |
+| 6.18.0 | Adopted the standard `src/` package layout without changing installed imports or the public API; strengthened built-wheel, static, dependency-audit and examples gates; and raised measured line coverage to 99%. |
 | 6.17.0 | Remediated the JOSS dry-run audit with portable paths, substantive generated API pages and importable version metadata; repaired flat factorlasso covariance plots; and refreshed the MATF-CMA custom eleven-factor replication snapshot. |
 | 6.16.0 | Replaced the default risk-lineage matcher's NetworkX runtime dependency with a deterministic sparse SciPy assignment, then moved canonical lineage analytics to factorlasso 0.14; the former OptimalPortfolios module is a deprecated compatibility shim. |
 | 6.15.0 | Added declarative causal cluster smoothing, preserved FCGL/HCGL semantics for externally supplied partitions, and raised the factorlasso floor to 0.13.0. |
@@ -1216,7 +1217,7 @@ If you use optimalportfolios in your research, please cite it as:
   author={Sepp, Artur},
   title={OptimalPortfolios: Implementation of optimisation analytics for constructing and backtesting optimal portfolios in Python},
   year={2026},
-  version={6.17.0},
+  version={6.18.0},
   url={https://github.com/ArturSepp/OptimalPortfolios}
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "optimalportfolios"
-version = "6.17.0"
+version = "6.18.0"
 description = "Implementation of optimisation analytics for constructing and backtesting optimal portfolios in Python"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2180,7 +2180,7 @@ wheels = [
 
 [[package]]
 name = "optimalportfolios"
-version = "6.17.0"
+version = "6.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "cvxpy", version = "1.7.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary
- bump project, citation and README release metadata to 6.18.0
- fold the accumulated Unreleased notes into the dated 6.18.0 section
- regenerate uv.lock for the new project version

## Verification
- uv lock --check: passed
- exact-wheel version import: 6.18.0 from clean site-packages
- release metadata tests: 4 passed
- wheel and sdist build: passed
- twine check: passed for both artifacts
- wheel inventory: tests and offline fixture included; src/, examples/ and papers/ absent
- sdist inventory: src/optimalportfolios included; examples/ and papers/ absent

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Bumped project version from 6.17.0 to 6.18.0.</li>
<li>Adopted the standard src/ package layout without changing public API or imports.</li>
<li>Strengthened CI/CD gates including built-wheel, static analysis, dependency-audit, and examples.</li>
<li>Raised the test coverage floor from 95% to 99%.</li>
</ul></div>