### PR TITLE
Correct the 6.21.0 coverage-floor counts and refresh the live test count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Every file matching pytest's default patterns — `*_test.py` **and** `test_*.py
 
 ```bash
 uv sync --extra dev                                      # editable install, versions from uv.lock
-uv run pytest                                            # run the test suite (1336 tests, ~3 min)
+uv run pytest                                            # run the test suite (1394 tests, ~3 min)
 uv run pytest src/optimalportfolios/optimization/tests/constraints_test.py -v
 uv run --only-group lint ruff check src/optimalportfolios/  # lint (papers/ is excluded)
 uv run --only-group lint interrogate                     # docstring coverage, must stay at 100%
@@ -110,7 +110,7 @@ It has two lanes, and the split is **derived rather than listed**: `.github/scri
 
 That `network` job carries a job-level `if`, which `static.yml` deliberately does not. The distinction matters: a skipped job reports *success*, so a guard is only ever safe on a job that must never gate. That one qualifies twice — excluded from the PR path by the condition, and `continue-on-error` on top. Do not add it to branch protection.
 
-Line coverage is **100.00%** on the 1336-test dev suite, and the ubuntu/3.12 matrix entry gates
+Line coverage is **100.00%** on the 1394-test dev suite, and the ubuntu/3.12 matrix entry gates
 `pytest --cov=optimalportfolios` at `fail_under = 100`. This is no longer a ratchet: at 100% an
 uncovered line is always something the change under review introduced, which is the same argument
 the 100% `interrogate` bar rests on. Lowering the floor requires a dated `CHANGELOG.md` note.
@@ -133,7 +133,7 @@ and is reviewed by eye rather than by assertion. Put anything with a numerical c
 `reports/`, where it is measured. Measure on a `[dev]` install.
 
 `[dev]` is pytest and pytest-cov, and nothing else. It previously also carried `networkx` and
-`optimalportfolios[data]`; neither enabled a single test — collection is 1336 either way. The
+`optimalportfolios[data]`; neither enabled a single test — collection is 1394 either way. The
 `data` extra was there for the **examples**, not the suite: no test imports yfinance, and the
 eleven files that do all live under root-level `examples/`, which is excluded from distributions
 and never collected. `networkx` was orphaned when the risk-lineage analytics moved to FactorLasso

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,14 @@ hierarchical risk parity, and safer inverse risk-budget calibration while preser
 direct risk-budgeting import paths.
 
 **Coverage floor raised to 100% (2026-08-14):** `fail_under` rises from `99` to `100`; measured
-coverage is 100.00% on 1321 tests, up from 99.09% on 1277. It is no longer a ratchet — at 100% an
-uncovered line is always something the change under review introduced, the same argument the 100%
-`interrogate` bar rests on. Five lines carry `# pragma: no cover`, each with a comment at the site:
-two defensive raises in `risk_budgeting_solver.py` that only a pinned solver pathology would reach,
-and three branches that are dead as written.
+coverage was 100.00% on the then-current 1336-test suite, up from 99.09% on 1277. It is no longer a
+ratchet — at 100% an uncovered line is always something the change under review introduced, the same
+argument the 100% `interrogate` bar rests on. Eight lines carry `# pragma: no cover`, each with a
+comment at the site: two defensive raises in `optimization/risk_allocation/risk_budgeting_solver.py`
+that only a pinned solver pathology would reach; three branches that are dead as written; and three
+that are reachable only from an environment the measuring cell is not — `__init__.py`'s
+`PackageNotFoundError` fallback wants an uninstalled source tree, and the two in `conftest.py` want
+an installed wheel with no checkout around it. `AGENTS.md` carries the site-by-site account.
 
 Getting there needed `[tool.coverage.report] precision = 2`, because the intermediate floors were
 fractional and unreachable without it: coverage.py rounds the measured total to `precision` places

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ dependencies. There is no `jupyter` extra: the package imports none of the Jupyt
 repository-only Colab quickstart uses Google's hosted runtime. Install notebook tooling separately
 for local notebooks. The `dev` and `docs` extras remain contributor toolchains.
 
-`dev` is deliberately minimal: the suite collects the same 1336 tests with or without the
+`dev` is deliberately minimal: the suite collects the same 1394 tests with or without the
 optional extras, so nothing else belongs in it. The lint tools are not an extra at all — they
 live in the `lint` dependency-group, which never ships to a user. To run the repository-root
 `examples/`, which do use `yfinance`, install `[dev,data]` or `[all]`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ docs = [
 # twelve matrix cells bought nothing. They live in the `lint` dependency-group below.
 #
 # Two entries were removed for the same reason -- neither enabled a single test. Collection is
-# 1336 tests with them and 1336 without:
+# 1394 tests with them and 1394 without:
 #
 #   * `optimalportfolios[data]` was here for the *examples*, not the suite. No test imports
 #     yfinance; the eleven files that do all live under root-level `examples/`, which is
@@ -247,11 +247,11 @@ omit = ["*/tests/*", "*/examples/*", "papers/*", "*/reports/*"]
 # pragma present. Eight is the number of decisions taken here; fourteen is the tool's total.
 #
 # Measure on a `[dev]` install, which is what the 3.12 leg of the `test` job in ci.yml does.
-# That is now pytest and pytest-cov over the core tree: the suite collects the same 1336 tests
+# That is now pytest and pytest-cov over the core tree: the suite collects the same 1394 tests
 # with or without the optional extras, so the measured scope does not depend on them.
 #
 # `precision` is not load-bearing at a floor of 100 — coverage.py never rounds a total *up* to
-# 100% while lines are missing, so a single uncovered line in 5412 reports 99% and fails the gate
+# 100% while lines are missing, so a single uncovered line in 5678 reports 99% and fails the gate
 # at either precision (verified both ways). It is kept for two smaller reasons: it is what let the
 # floor be raised in sub-percent steps on the way here (at precision 0 the total is rounded before
 # the comparison, so a fractional `fail_under` like 99.1 could never be met), and it reports the


### PR DESCRIPTION
Closes #73.

The coverage-floor entry stated **1321 tests** and **five** `# pragma: no cover` lines. Both
figures were written mid-PR and never remeasured after the follow-up work landed. Three other
documents in the same tree already disagreed with them.

Rebased onto `main` at `a91a4a4`. The rebase changed what this PR has to say, in two ways worth
reading before the diff:

- **The entry has shipped.** It no longer sits under `[Unreleased]` — the 6.21.0 release swept it
  into `## [6.21.0] - 2026-08-17`. It is now a historical record, not a pending release note, so
  the correction is phrased in the past tense against the suite as it was, and deliberately does
  *not* track the live count.
- **The live count has moved on.** `main` now collects **1394** tests, not 1336. That makes the
  three documents which describe the *current* tree stale in turn, so they are updated here too,
  in a separate commit.

## Two commits, on purpose

| Commit | Scope | Count |
| --- | --- | --- |
| `Correct the two counts in the 6.21.0 coverage-floor entry` | `CHANGELOG.md` | stays **1336** — historical |
| `Update the documented live test count to 1394` | `AGENTS.md`, `README.md`, `pyproject.toml` | becomes **1394** — live |

Keeping them apart is the whole point: a changelog entry for a shipped release records what was
measured at that release, while those three files track the tree as it stands. Collapsing the two
is what produced the original defect.

## Evidence

Fresh measurement on `main` at `a91a4a4`:

```
TOTAL                                            5678      0   100.00%
Required test coverage of 100.0% reached. Total coverage: 100.00%
1394 passed, 226 warnings in 180.20s (0:03:00)
```

`pytest --collect-only` collects **1394 tests across 66 test files**.

`git grep "pragma: no cover" -- src` returns **eight** sites, not five. The canonical
risk-budgeting paths now live under `optimization/risk_allocation`; the `optimization.general`
compatibility modules that once fronted them were removed in 6.21.1:

```
src/optimalportfolios/__init__.py:14
src/optimalportfolios/alphas/signals/utils.py:207
src/optimalportfolios/conftest.py:65
src/optimalportfolios/conftest.py:81
src/optimalportfolios/covar_estimation/factor_covar_estimator.py:384
src/optimalportfolios/optimization/risk_allocation/risk_budgeting.py:518
src/optimalportfolios/optimization/risk_allocation/risk_budgeting_solver.py:360
src/optimalportfolios/optimization/risk_allocation/risk_budgeting_solver.py:393
```

## What changed in the CHANGELOG

The two figures and the sentence describing the pragmas, and nothing else.

The measurement now reads *"measured coverage was 100.00% on the then-current 1336-test suite"* —
past tense and explicitly dated, so a future reader cannot mistake it for a claim about the tree
they are looking at.

The prose was incomplete as well as the count. It accounted for five sites — the two defensive
raises in `risk_budgeting_solver.py` and the three branches dead as written — and omitted the
three reachable only from an environment the measuring cell is not. That third group is now
named, using the wording `AGENTS.md` already carries, with a pointer there for the site-by-site
account so the two documents cannot drift apart again.

`up from 99.09% on 1277` is left alone: it describes the pre-change state, is not measurable from
this tree, and was not part of the finding.

## What changed in the three live documents

The seven `1336` references become `1394`. Two claims were re-verified rather than just
renumbered:

- **The extras invariance.** All three files assert collection is unchanged by the optional
  extras. Still true: `--extra data --extra reports` also collects 1394.
- **The statement total** quoted in the `precision` note had drifted the same way, 5412 → 5678.
  The argument it supports is unaffected — coverage.py still refuses to round a total up to 100%
  while any line is missing.

The eight pragma sites and the ten statement lines they suppress are unchanged, so those counts
stay as written. `AGENTS.md`'s `~3 min` runtime still holds at 180s.

## Why it is worth fixing

**Nothing in `src/` reads `CHANGELOG.md`**, so no gate could have caught the original defect. And
nothing gates the live counts either, which is why they drifted again between the first push and
this rebase — the same failure mode, twice, in one PR.

## Verification

- `pytest --cov=optimalportfolios` — 1394 passed, 100.00%, gate satisfied.
- `pytest src/optimalportfolios/tests/` — 316 passed, including `readme_test.py` and
  `doctest_test.py`, which execute the documentation.
- `ruff check --select TID251,TID253,ICN,F src/optimalportfolios/` — all checks passed.
- `interrogate -v` — PASSED, 100.0%.
- No `1321`, `Five lines`, or live `1336` remains.

Documentation and comments only — no source, config or workflow behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
