### PR TITLE
Add .ruff_cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,12 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# ruff
+# Ruff also writes a .gitignore containing `*` inside this directory, so the cache stays out
+# of git status without this line. Naming it here means the rule lives with the repository's
+# own ignores rather than depending on that behaviour.
+.ruff_cache/
+
 /dist/
 *.xml
 *.pyc


### PR DESCRIPTION
`.ruff_cache/` stays out of `git status` today, but not because of anything in this repository. Ruff writes a `.gitignore` containing `*` inside its own cache directory, and that is what git is matching on.

That works until it does not. The rule lives in generated content, is owned by a tool rather than by the repository, and is absent whenever the cache directory has been removed and ruff has not yet recreated it. `.mypy_cache/` and `.pyre/` are already named explicitly a few lines above, so the cache of the linter this project actually runs is the odd one out.

## Verified

Deleting ruff's internal file and confirming the rule still applies:

```console
$ git check-ignore -v .ruff_cache
.gitignore:165:.ruff_cache/	.ruff_cache

$ rm -f .ruff_cache/.gitignore
$ git check-ignore -v .ruff_cache
.gitignore:165:.ruff_cache/	.ruff_cache
```

Before the change, `git check-ignore` attributes the match to `.ruff_cache/.gitignore` instead.

No behaviour change: the directory was already untracked, so nothing enters or leaves the index. One file, six lines, no source, test or workflow change.

## Note

Split out of #76 on review — it is an independent one-line fix and was riding along there as a second topic, which `CONTRIBUTING.md:123` asks against. #76 has been reduced to the Makefile alone and no longer touches `.gitignore`; the two do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
