### PR TITLE
Make paper scripts portable and document their data

### DIFF
--- a/papers/crypto_allocation_risk_2023/README.md
+++ b/papers/crypto_allocation_risk_2023/README.md
@@ -1,30 +1,50 @@
-Implementation of simulations for paper:
+# Optimal Allocation to Cryptocurrencies in Diversified Portfolios
 
-Sepp A. (2023) Optimal Allocation to Cryptocurrencies in Diversified Portfolios,
-Risk (October 2023, 1-6), Available at SSRN: https://ssrn.com/abstract=4217841
+This directory contains the simulations for:
 
-The analysis presented in the paper can be replicated or extended using this module
+Sepp A. (2023), "Optimal Allocation to Cryptocurrencies in Diversified Portfolios",
+*Risk*, October 2023, 1–6. [SSRN 4217841](https://ssrn.com/abstract=4217841).
 
-Implementation steps:
-1) Populate the time series of asset prices in the investable universe using
-```python 
-optimaportfolios/examples/crypto_allocation/load_prices.py
+## Environment
+
+From a repository checkout, install the optional data and reporting dependencies explicitly:
+
+```bash
+uv sync --extra dev --extra data --extra reports
 ```
 
-Price data for some assets can be fetched from local csv files, some can be generated on the fly 
+The scripts use the current checkout. They do not carry PEP 723 metadata that could silently install
+a released `optimalportfolios` version instead.
 
-Run
-```python 
-update_prices() 
+## Data
+
+The `data/` directory includes the CSV inputs that can be redistributed. Rebuilding the combined
+price file with `update_prices_with_yf()` additionally requires two licensed Société Générale index
+workbooks that the repository cannot ship:
+
+- `CTA_Historical.xlsx` — [SG CTA Index](https://wholesale.banking.societegenerale.com/en/prime-services-indices/)
+- `Macro_Trading_Index_Historical.xlsx` — [SG Macro Trading Index](https://wholesale.banking.societegenerale.com/fileadmin/indices_feeds/Macro_Trading_Index_Historical.xls)
+
+Place authorised `.xlsx` copies beside the CSV files in `data/`. The loader checks for both before
+starting any Yahoo download and reports their exact paths when either is absent. The Bloomberg route
+requires a Bloomberg terminal and `bbg-fetch`; it is not the public reproduction path.
+
+Yahoo price histories are downloaded at runtime and may be revised by the provider. A fresh download
+therefore reproduces the method, not necessarily the exact published values. The committed combined
+CSV files are the stable inputs for comparing the stored analysis.
+
+## Running the scripts
+
+```bash
+uv run --no-sync python papers/crypto_allocation_risk_2023/load_prices.py
+uv run --no-sync python papers/crypto_allocation_risk_2023/article_figures.py
+uv run --no-sync python papers/crypto_allocation_risk_2023/backtest_portfolios_for_article.py
 ```
 
-2) Generate article figures using unit tests in
- ```python 
-optimaportfolios/examples/crypto_allocation/article_figures.py
-```
+Generated reports default to the gitignored
+`outputs/crypto_allocation_risk_2023/` directory at the repository root. Override it without editing
+the scripts by setting `OPTIMALPORTFOLIOS_OUTPUT_DIR`; for example in PowerShell:
 
-3) Generate reports of simulated investment portfolios as reported in the article
- ```python 
-optimaportfolios/examples/crypto_allocation/backtest_portfolios_for_article.py
+```powershell
+$env:OPTIMALPORTFOLIOS_OUTPUT_DIR = 'D:\portfolio-reports\crypto'
 ```
-

--- a/papers/crypto_allocation_risk_2023/article_figures.py
+++ b/papers/crypto_allocation_risk_2023/article_figures.py
@@ -11,7 +11,12 @@ import qis
 from qis import TimePeriod, PerfParams, BenchmarkReturnsQuantilesRegime, PerfStat
 
 import optimalportfolios.utils.gaussian_mixture as gm
-from papers.crypto_allocation_risk_2023.load_prices import Assets, load_prices, load_risk_free_rate
+from papers.crypto_allocation_risk_2023.load_prices import (
+    Assets,
+    OUTPUT_PATH,
+    load_prices,
+    load_risk_free_rate,
+)
 
 PERF_PARAMS = PerfParams(freq_vol='ME', freq_reg='ME', freq_drawdown='ME', rates_data=load_risk_free_rate())
 REGIME_CLASSIFIER = BenchmarkReturnsQuantilesRegime(freq='QE')
@@ -263,8 +268,10 @@ def run_local_test(local_test: LocalTests):
     These are integration tests that download real universe and generate reports.
     Use for quick verification during product_development.
     """
-    FIGURE_SAVE_PATH = "C://Users//artur//OneDrive//My Papers//Published Papers//CryptoAllocation. Zurich. Jan 2022//UpdatedFigures//"
+    FIGURE_SAVE_PATH = OUTPUT_PATH
     SAVE_FIGS = True
+    if SAVE_FIGS:
+        FIGURE_SAVE_PATH.mkdir(parents=True, exist_ok=True)
 
     end_date = '30Jun2023'
 

--- a/papers/crypto_allocation_risk_2023/backtest_portfolios_for_article.py
+++ b/papers/crypto_allocation_risk_2023/backtest_portfolios_for_article.py
@@ -9,15 +9,20 @@ import pybloqs as p
 import qis as qis
 from qis import TimePeriod, PerfParams, BenchmarkReturnsQuantilesRegime, PerfStat, PortfolioData
 
-from papers.crypto_allocation_risk_2023.load_prices import Assets, load_prices, load_risk_free_rate
+from papers.crypto_allocation_risk_2023.load_prices import (
+    Assets,
+    OUTPUT_PATH,
+    load_prices,
+    load_risk_free_rate,
+)
 from optimalportfolios.reports.marginal_backtest import OptimisationParams, OptimisationType, backtest_marginal_optimal_portfolios
 from optimalportfolios.reports.config import KWARGS_SUPTITLE, KWARGS_TITLE, KWARGS_FIG, KWARGS_TEXT
 
 PERF_PARAMS = PerfParams(freq_vol='ME', freq_reg='ME', freq_drawdown='ME', rates_data=load_risk_free_rate())
 REGIME_CLASSIFIER = BenchmarkReturnsQuantilesRegime(freq='QE')
 
-LOCAL_PATH = "C://Users//artur//OneDrive//analytics//outputs//"
-FIGURE_SAVE_PATH = LOCAL_PATH # "C://Users//artur//OneDrive//My Papers//Published Papers//CryptoAllocation. Zurich. Jan 2022//UpdatedFigures//"
+LOCAL_PATH = OUTPUT_PATH
+FIGURE_SAVE_PATH = OUTPUT_PATH
 
 SAVE_FIGS = False
 
@@ -103,6 +108,7 @@ def produce_article_backtests(time_period: TimePeriod,
     plot weights time series
     plot performance attribution
     """
+    LOCAL_PATH.mkdir(parents=True, exist_ok=True)
     crypto_assets = ['BTC', 'ETH']
     prices_alls = {}
     for crypto_asset in crypto_assets:
@@ -457,8 +463,9 @@ def produce_article_backtests(time_period: TimePeriod,
 
     b_report = p.VStack(vblocks)
     filename = f"Crypto_portfolios_backtests_{pd.Timestamp.now().strftime('%Y%m%d_%H%M')}.pdf"
-    b_report.save(filename)
-    print(f"saved article report to {filename}")
+    report_file = LOCAL_PATH / filename
+    b_report.save(str(report_file))
+    print(f"saved article report to {report_file}")
     qis.save_df_to_excel(dfs_out, file_name=filename, local_path=LOCAL_PATH)
     print(f"saved article tables to {filename}.xls")
     plt.close('all')

--- a/papers/crypto_allocation_risk_2023/load_prices.py
+++ b/papers/crypto_allocation_risk_2023/load_prices.py
@@ -4,6 +4,7 @@ update_prices_with_bloomberg() must used with  Bloomberg open
 update_prices_with_yf() uses yfinance + some universe uploaded manually
 NB: CmcScraper stopped working so now only option is to use bloomberg
 """
+import os
 from pathlib import Path
 import pandas as pd
 import yfinance as yf
@@ -14,9 +15,13 @@ from enum import Enum
 # from cryptocmd import CmcScraper  its stopped working: todo - remove
 import qis as qis
 
-# add the local path to universe files
-LOCAL_PATH = Path(__file__).parent.joinpath('/papers/crypto_allocation_risk_2023/data//')
-print(LOCAL_PATH)
+# Repository data and generated-output locations. The output directory can be redirected without
+# editing the published script; its default is the repository's gitignored outputs/ tree.
+LOCAL_PATH = Path(__file__).resolve().parent / 'data'
+OUTPUT_PATH = Path(os.environ.get(
+    'OPTIMALPORTFOLIOS_OUTPUT_DIR',
+    Path(__file__).resolve().parents[2] / 'outputs' / 'crypto_allocation_risk_2023',
+)).expanduser().resolve()
 
 
 # universe sources
@@ -27,6 +32,19 @@ MACRO_PRICE = 'Macro_Trading_Index_Historical'  # Macro SCTas from https://whole
 
 PRICE_DATA_FILE = 'crypto_allocation_prices'
 PRICE_DATA_FILE_UPDATED = 'crypto_allocation_prices_updated'
+
+LICENSED_PRICE_FILES = (f'{CTA_PRICE}.xlsx', f'{MACRO_PRICE}.xlsx')
+
+
+def require_licensed_price_files() -> None:
+    """Fail clearly when the two non-redistributable SG workbooks are absent."""
+    missing = [name for name in LICENSED_PRICE_FILES if not (LOCAL_PATH / name).is_file()]
+    if missing:
+        names = ', '.join(missing)
+        raise FileNotFoundError(
+            f"Required licensed input file(s) are not redistributed: {names}. "
+            f"Place authorised .xlsx copies in {LOCAL_PATH}. See README.md for the sources."
+        )
 
 
 class Assets(Enum):
@@ -47,6 +65,7 @@ def update_prices_with_yf() -> pd.DataFrame:
     """
     generate price universe using yfinance
     """
+    require_licensed_price_files()
     btc = create_btc_price()
     eth = create_eth_price(btc_price=qis.load_df_from_csv(file_name=BTC_PRICES_FROM_2010, local_path=LOCAL_PATH).iloc[:, 0])
     bal = create_balanced_price()

--- a/papers/crypto_allocation_risk_2023/perf_crypto_portfolios.py
+++ b/papers/crypto_allocation_risk_2023/perf_crypto_portfolios.py
@@ -1,7 +1,7 @@
 """
 backtesting report for BTC portfolios
 to use pybloqs for pandas > 2.x
-locate file "...\Lib\site-packages\pybloqs\jinja\table.html"
+locate file "...\\Lib\\site-packages\\pybloqs\\jinja\\table.html"
 change line 44 from:
 {% for col_name, cell in row.iteritems() %}
 to:
@@ -19,7 +19,12 @@ import pybloqs as p
 import qis as qis
 from qis import TimePeriod, PerfParams, BenchmarkReturnsQuantilesRegime, PerfStat
 
-from papers.crypto_allocation_risk_2023.load_prices import Assets, load_prices, load_risk_free_rate
+from papers.crypto_allocation_risk_2023.load_prices import (
+    Assets,
+    OUTPUT_PATH,
+    load_prices,
+    load_risk_free_rate,
+)
 from optimalportfolios.reports.marginal_backtest import OptimisationType
 from optimalportfolios.reports.config import KWARGS_SUPTITLE, KWARGS_TITLE, KWARGS_FIG, KWARGS_TEXT
 from papers.crypto_allocation_risk_2023.backtest_portfolios_for_article import run_joint_backtest
@@ -27,8 +32,8 @@ from papers.crypto_allocation_risk_2023.backtest_portfolios_for_article import r
 PERF_PARAMS = PerfParams(freq_vol='ME', freq_reg='ME', freq_drawdown='ME', rates_data=load_risk_free_rate())
 REGIME_CLASSIFIER = BenchmarkReturnsQuantilesRegime(freq='QE')
 
-LOCAL_PATH = "C://Users//artur//OneDrive//analytics//outputs//"
-FIGURE_SAVE_PATH = "C://Users//artur//OneDrive//My Papers//Working Papers//CryptoAllocation. Zurich. Jan 2022//figs1//"
+LOCAL_PATH = OUTPUT_PATH
+FIGURE_SAVE_PATH = OUTPUT_PATH
 SAVE_FIGS = False
 
 
@@ -82,9 +87,12 @@ def report_backtest_all_optimisation_types(time_period: TimePeriod,
                                          **FIG_KWARGS)
         b_reports.append(p.Block(report))
     b_reports = p.VStack(b_reports, styles={"page-break-after": "always"})
-    filename = f"{LOCAL_PATH}{crypto_asset}_backtests_{pd.Timestamp.now().strftime('%Y%m%d_%H%M')}.pdf"
-    b_reports.save(filename)
-    print(f"saved optimisation report to {filename}")
+    LOCAL_PATH.mkdir(parents=True, exist_ok=True)
+    report_file = LOCAL_PATH / (
+        f"{crypto_asset}_backtests_{pd.Timestamp.now().strftime('%Y%m%d_%H%M')}.pdf"
+    )
+    b_reports.save(str(report_file))
+    print(f"saved optimisation report to {report_file}")
 
 
 def create_performance_attrib_table(time_period_dict: Dict[str, TimePeriod],
@@ -424,8 +432,9 @@ def backtest_constant_weight_portfolios(crypto_asset: str = 'BTC',
                                   heatmap_columns=[1, 2],
                                   ax=ax,
                                   **kwargs)
-    filename = f"{LOCAL_PATH}{crypto_asset}_constant_weight_backtests.pdf"
-    qis.save_figs_to_pdf(figs, file_name=filename)
+    LOCAL_PATH.mkdir(parents=True, exist_ok=True)
+    report_file = LOCAL_PATH / f"{crypto_asset}_constant_weight_backtests.pdf"
+    qis.save_figs_to_pdf(figs, file_name=str(report_file))
 
 
 class LocalTests(Enum):

--- a/papers/robust_optimisation_jpm_2026/README.md
+++ b/papers/robust_optimisation_jpm_2026/README.md
@@ -60,14 +60,19 @@ for TAA tracking error) and the full model (D included, for SAA risk budgeting).
 
 ## Running the example
 
+From a repository checkout, install the data extra and run the script against the current source:
+
 ```bash
-pip install optimalportfolios yfinance qis
-python hcgl_covar_for_rolling_backtest.py
+uv sync --extra dev --extra data
+uv run --no-sync python papers/robust_optimisation_jpm_2026/hcgl_covar_for_rolling_backtest.py
 ```
 
 The script uses `yfinance` to download price data for a 6-asset multi-asset
 universe: SPY (US equities), EZU (Europe equities), EEM (EM equities),
 TLT (US Treasuries), HYG (High Yield), GLD (Gold).
+Those histories can be revised by the provider, so a fresh run reproduces the method but is not
+expected to reproduce the exact published numbers bit-for-bit. For an installed release rather than
+a checkout, use `pip install "optimalportfolios[data]"`.
 
 
 ## Code walkthrough


### PR DESCRIPTION
Part of #77.

## Changes

- resolve the crypto paper's data directory relative to its script instead of the filesystem root
- route every crypto paper report to a gitignored repository output directory, configurable with `OPTIMALPORTFOLIOS_OUTPUT_DIR`
- remove all contributor-machine output paths, including the one in `article_figures.py`
- fail before any Yahoo request when the two non-redistributable SG workbooks are absent, naming both required `.xlsx` files and their destination
- replace stale example paths and document the exact `uv` extras, licensed-input boundary, output override, and live-data reproducibility limit
- document the same live-download limitation for the robust-optimisation paper

No return, covariance, optimiser, random-seed, or other numerical logic changes.

## Verification

```
data_path= ...\papers\crypto_allocation_risk_2023\data
output_path= ...\.pytest_cache\custom-output
stored_prices_shape= (6165, 10)
```

The guard fails as intended:

```
FileNotFoundError: Required licensed input file(s) are not redistributed:
CTA_Historical.xlsx, Macro_Trading_Index_Historical.xlsx.
```

All four executable paper modules compile successfully, both reporting modules resolve the configured output path under stubbed offline providers, `rg` finds no remaining `C://Users` or root-discarding `joinpath('/papers...')`, and `git diff --check` passes.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored output directory management to use a configurable environment variable (OPTIMALPORTFOLIOS_OUTPUT_DIR) instead of hardcoded local paths.</li>
<li>Updated README.md with environment setup instructions, data requirements, and usage examples.</li>
<li>Added a validation check for required non-redistributable licensed price files in load_prices.py.</li>
<li>Standardized path handling across scripts to ensure consistent output directory creation and file saving.</li>
</ul></div>